### PR TITLE
DoctrineCollectionDataSource: non strict comparison

### DIFF
--- a/src/DataSource/DoctrineCollectionDataSource.php
+++ b/src/DataSource/DoctrineCollectionDataSource.php
@@ -15,6 +15,7 @@ use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 use Ublaboo\DataGrid\Utils\Sorting;
 
+
 final class DoctrineCollectionDataSource extends FilterableDataSource implements IDataSource, IAggregatable
 {
 
@@ -89,6 +90,9 @@ final class DoctrineCollectionDataSource extends FilterableDataSource implements
 	{
 		foreach ($condition as $column => $value) {
 			$expr = Criteria::expr()->eq($column, $value);
+			if (is_string($value) && is_numeric($value)) {
+				$expr = Criteria::expr()->orX($expr, Criteria::expr()->eq($column, (int) $value));
+			}
 			$this->criteria->andWhere($expr);
 		}
 
@@ -274,3 +278,4 @@ final class DoctrineCollectionDataSource extends FilterableDataSource implements
 		call_user_func($aggregationCallback, clone $this->data_source);
 	}
 }
+


### PR DESCRIPTION
Datagrid does not work properly with data sources using strict comparison in `\Ublaboo\DataGrid\DataSource\IDataSource::filterOne` method.

Strict comparison in DoctrineCollectionDataSource is done at https://github.com/doctrine/collections/blob/master/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php#L134.

Other data sources are not using strict comparison.

There is problem when filtering by id from handle methods which is always string and database id in my case is integer.

Is this the right place for fix or numeric string `$id` should be converted to integer in methods `\Ublaboo\DataGrid\DataGrid::handleGetItemDetail` and `\Ublaboo\DataGrid\DataGrid::redrawItem` at lines with `\Ublaboo\DataGrid\DataGrid::$redraw_item` property assignment?