### PR TITLE
Dibi 2.x and 3.x compatibility fix

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -35,10 +35,10 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 
 
 	/**
-	 * @param DibiFluent $data_source
+	 * @param DibiFluent|Dibi\Fluent $data_source
 	 * @param string $primary_key
 	 */
-	public function __construct(DibiFluent $data_source, $primary_key)
+	public function __construct($data_source, $primary_key)
 	{
 		$this->data_source = $data_source;
 		$this->primary_key = $primary_key;

--- a/src/Row.php
+++ b/src/Row.php
@@ -17,6 +17,7 @@ use Nette\Utils\Html;
 use Nextras;
 use Ublaboo\DataGrid\Exception\DataGridException;
 use Ublaboo\DataGrid\Utils\PropertyAccessHelper;
+use Dibi\Row as DRow;
 
 class Row
 {
@@ -91,7 +92,7 @@ class Row
 		} elseif ($this->item instanceof Nextras\Orm\Entity\Entity) {
 			return $this->getNextrasEntityProperty($this->item, $key);
 
-		} elseif ($this->item instanceof DibiRow) {
+		} elseif ($this->item instanceof DibiRow || $this->item instanceof DRow) {
 			return $this->item->{$this->formatDibiRowKey($key)};
 
 		} elseif ($this->item instanceof ActiveRow) {


### PR DESCRIPTION
I am using the latest dibi and there were two exceptions thrown in Row.php and DibiFluentDataSource.php files because of version with namespaces or old one without namespaces.