### PR TITLE
reset-sort-when-reseting-filter

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2287,8 +2287,9 @@ class DataGrid extends Nette\Application\UI\Control
 			$this->deleteSessionData('_grid_has_filtered');
 		}
 
-		if ($this->default_sort_use_on_reset) {
-			$this->deleteSessionData('_grid_has_sorted');
+		if ($this->default_sort_use_on_reset && $this->getSessionData('_grid_has_sorted')) {
+			$this->sort = $this->default_sort;
+			$this->saveSessionData('_grid_sort', $this->default_sort);
 		}
 
 		foreach ($this->getSessionData() as $key => $value) {


### PR DESCRIPTION
this should repair bug from this comment: https://github.com/ublaboo/datagrid/issues/601#issuecomment-368484053
`It does not work (means the grid default sort is not applied) when reseting filters with the "reset filters" button.`
-> sort will be reset when `reset filter` button is hit