### PR TITLE
travis.yml: Removed php 7.2 from tests (due to an nette/object in nex…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
…tras package)