### PR TITLE
Fix conditionCallback invocation when using DoctrineCollectionDataSource

### DIFF
--- a/src/DataSource/DoctrineCollectionDataSource.php
+++ b/src/DataSource/DoctrineCollectionDataSource.php
@@ -21,17 +21,17 @@ final class DoctrineCollectionDataSource extends FilterableDataSource implements
 	/**
 	 * @var Collection
 	 */
-	private $data_source;
+	protected $data_source;
 
 	/**
 	 * @var string
 	 */
-	private $primary_key;
+    protected $primary_key;
 
 	/**
 	 * @var Criteria
 	 */
-	private $criteria;
+    protected $criteria;
 
 
 	/**


### PR DESCRIPTION
Now, when using DoctrineCollectionDataSource, application fails on condition callback invocation. it's caused by DoctrineCollectionDataSource having private access to data_source property instead of protected. 

Please merge

Thanks.