### PR TITLE
Allow zero value in custom editable value

### DIFF
--- a/assets/src/datagrid.coffee
+++ b/assets/src/datagrid.coffee
@@ -486,7 +486,7 @@ $(document).on('click', '[data-datagrid-editable-url]', (event) ->
 
 		cellValue = cell.html().trim().replace('<br>', '\n')
 
-		if cell.data('datagrid-editable-value')
+		if cell.attr('data-datagrid-editable-value')
 			valueToEdit = cell.data('datagrid-editable-value')
 		else
 			valueToEdit = cellValue


### PR DESCRIPTION
If html attribute data-datagrid-editable-value="0" then value was loaded from table cell, not data attribute. Value should be loaded from data-datagrid-editable-value attribute if exists.