### PR TITLE
Fix filter calendar icon

### DIFF
--- a/src/templates/datagrid_filter_date.latte
+++ b/src/templates/datagrid_filter_date.latte
@@ -11,7 +11,9 @@
 			<div class="input-group input-group-sm datagrid-input-group-full-width">
 				{input $input}
 				<label n:name="$input" class="input-group-addon input-group-append">
-					<i class="input-group-text {$icon_prefix}calendar"></i>
+					<span class="input-group-text">
+						<i class="{$icon_prefix}calendar"></i>
+					</span>
 				</label>
 			</div>
 		</div>
@@ -21,7 +23,9 @@
 		<div class="input-group input-group-sm">
 			{input $input}
 			<label n:name="$input" class="input-group-addon input-group-append">
-				<i class="input-group-text {$icon_prefix}calendar"></i>
+				<span class="input-group-text">
+					<i class="{$icon_prefix}calendar"></i>
+				</span>
 			</label>
 		</div>
 	</div>

--- a/src/templates/datagrid_filter_daterange.latte
+++ b/src/templates/datagrid_filter_daterange.latte
@@ -13,7 +13,9 @@
 			<div class="input-group input-group-sm">
 				{input $container['from']}
 				<label n:name="$container['from']" class="input-group-addon input-group-append">
-					<i class="input-group-text {$icon_prefix}calendar"></i>
+					<span class="input-group-text">
+						<i class="{$icon_prefix}calendar"></i>
+					</span>
 				</label>
 			</div>
 		</div>
@@ -22,7 +24,9 @@
 			<div class="input-group input-group-sm">
 				{input $container['to']}
 				<label n:name="$container['to']" class="input-group-addon input-group-append">
-					<i class="input-group-text {$icon_prefix}calendar"></i>
+					<span class="input-group-text">
+						<i class="{$icon_prefix}calendar"></i>
+					</span>
 				</label>
 			</div>
 		</div>
@@ -32,14 +36,18 @@
 		<div class="input-group input-group-sm">
 			{input $container['from']}
 			<label n:name="$container['from']" class="input-group-addon input-group-append input-group-addon-first">
-				<i class="input-group-text {$icon_prefix}calendar"></i>
+				<span class="input-group-text">
+					<i class="{$icon_prefix}calendar"></i>
+				</span>
 			</label>
 
 			<div class="input-group-addon datagrid-col-filter-datte-range-delimiter">-</div>
 
 			{input $container['to']}
 			<label n:name="$container['to']" class="input-group-addon input-group-append">
-				<i class="input-group-text {$icon_prefix}calendar"></i>
+				<span class="input-group-text">
+					<i class="{$icon_prefix}calendar"></i>
+				</span>
 			</label>
 		</div>
 	</div>


### PR DESCRIPTION
Fixed missing calendar icon if Bootstrap 4 is used. Bootstrap 3 compatible.