### PR TITLE
Convert primary key to Nextras format at NextrasDataSource::sort

### DIFF
--- a/src/DataSource/NextrasDataSource.php
+++ b/src/DataSource/NextrasDataSource.php
@@ -275,7 +275,7 @@ class NextrasDataSource extends FilterableDataSource implements IDataSource
 			$order = $this->data_source->getQueryBuilder()->getClause('order');
 
 			if (ArraysHelper::testEmpty($order)) {
-				$this->data_source = $this->data_source->orderBy($this->primary_key);
+				$this->data_source = $this->data_source->orderBy($this->prepareColumn($this->primary_key));
 			}
 		}
 


### PR DESCRIPTION
Fixes following exception:

```
Nextras\Orm\InvalidArgumentException

Unsupported condition format. 
```

Exception is thrown when primary key is like `foreignKey.column` and default sort is not set.