### PR TITLE
Add check for __toString() in array row value

### DIFF
--- a/src/DataSource/NextrasDataSource.php
+++ b/src/DataSource/NextrasDataSource.php
@@ -275,7 +275,7 @@ class NextrasDataSource extends FilterableDataSource implements IDataSource
 			$order = $this->data_source->getQueryBuilder()->getClause('order');
 
 			if (ArraysHelper::testEmpty($order)) {
-				$this->data_source = $this->data_source->orderBy($this->primary_key);
+				$this->data_source = $this->data_source->orderBy($this->prepareColumn($this->primary_key));
 			}
 		}
 

--- a/src/Row.php
+++ b/src/Row.php
@@ -105,7 +105,13 @@ class Row
 			return $this->item->{$key};
 
 		} elseif (is_array($this->item)) {
-			return $this->item[$key];
+            $arrayKey = $this->item[$key];
+
+            if (is_object($arrayKey) && method_exists($arrayKey, '__toString')) {
+                return $arrayKey->__toString();
+            }
+
+            return $arrayKey;
 
 		} else {
 			/**

--- a/src/Row.php
+++ b/src/Row.php
@@ -105,13 +105,13 @@ class Row
 			return $this->item->{$key};
 
 		} elseif (is_array($this->item)) {
-            $arrayKey = $this->item[$key];
+			$arrayValue = $this->item[$key];
 
-            if (is_object($arrayKey) && method_exists($arrayKey, '__toString')) {
-                return $arrayKey->__toString();
-            }
+			if (is_object($arrayValue) && method_exists($arrayValue, '__toString')) {
+				return $arrayValue->__toString();
+			}
 
-            return $arrayKey;
+			return $arrayValue;
 
 		} else {
 			/**


### PR DESCRIPTION
When you tried to load array from query builder (with HYDRATE_ARRAY hydrator), and Entity has $id column of type UuidInterface or so on, it was returned in Row::getValue() instead of string (for instance in links). So I added checking for object type and __toString() function.