### PR TITLE
 Support for content icons (Google Material etc)

### DIFF
--- a/src/Traits/TButtonIcon.php
+++ b/src/Traits/TButtonIcon.php
@@ -20,10 +20,14 @@ trait TButtonIcon
 	/**
 	 * Set icon
 	 * @param string $icon
+	 * @param string $content
 	 */
-	public function setIcon($icon)
+	public function setIcon($icon, $content = '')
 	{
-		$this->icon = $icon;
+		$this->icon = (object)[
+			'class' => $class,
+			'content' => $content,
+		];
 
 		return $this;
 	}

--- a/src/Traits/TButtonIcon.php
+++ b/src/Traits/TButtonIcon.php
@@ -8,6 +8,8 @@
 
 namespace Ublaboo\DataGrid\Traits;
 
+use Ublaboo\DataGrid\Utils\IconData;
+
 trait TButtonIcon
 {
 
@@ -24,10 +26,7 @@ trait TButtonIcon
 	 */
 	public function setIcon($icon, $content = '')
 	{
-		$this->icon = (object)[
-			'class' => $class,
-			'content' => $content,
-		];
+		$this->icon = new IconData($icon, $content);
 
 		return $this;
 	}

--- a/src/Traits/TButtonTryAddIcon.php
+++ b/src/Traits/TButtonTryAddIcon.php
@@ -24,7 +24,11 @@ trait TButtonTryAddIcon
 	public function tryAddIcon(Html $el, $icon, $name)
 	{
 		if ($icon) {
-			$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon));
+			if (is_object($icon)) {
+				$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon->class)->setText($icon->content));
+			} else {
+				$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon));
+			}
 
 			if (strlen($name)) {
 				$el->addHtml('&nbsp;');

--- a/src/Traits/TButtonTryAddIcon.php
+++ b/src/Traits/TButtonTryAddIcon.php
@@ -10,22 +10,23 @@ namespace Ublaboo\DataGrid\Traits;
 
 use Nette\Utils\Html;
 use Ublaboo\DataGrid\DataGrid;
+use Ublaboo\DataGrid\Utils\IconData;
 
 trait TButtonTryAddIcon
 {
 
 	/**
 	 * Should the element has an icon?
-	 * @param  Html            $el
-	 * @param  string|null     $icon
-	 * @param  string          $name
+	 * @param  Html                  $el
+	 * @param  string|IconData|null  $icon
+	 * @param  string                $name
 	 * @return void
 	 */
 	public function tryAddIcon(Html $el, $icon, $name)
 	{
 		if ($icon) {
 			if (is_object($icon)) {
-				$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon->class)->setText($icon->content));
+				$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon->iconClass)->setText($icon->content));
 			} else {
 				$el->addHtml(Html::el('span')->class(DataGrid::$icon_prefix . $icon));
 			}

--- a/src/Utils/IconData.php
+++ b/src/Utils/IconData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Ublaboo\DataGrid\Utils;
+
+class IconData
+{
+	/**
+	 * @var string
+	 */
+	public $content;
+
+	/**
+	 * @var string
+	 */
+	public $iconClass;
+
+
+	/**
+	 * @param string  $content
+	 * @param string  $iconClass
+	 */
+	public function __construct($content, $iconClass)
+	{
+		$this->content = $content;
+		$this->iconClass = $iconClass;
+	}
+}


### PR DESCRIPTION
This future now support optional second argument for `setIcon`
```php
$button->setIcon('material-icons', 'cloud_download');
```
Thats print
```html
<a class="md-bnt" title="Download CSV" href="">
  <span class="material-icons">cloud_download</span>
  &nbsp;CSV
</a>
```

BC: no

_(squash commits into one?)_