### PR TITLE
Added method ::getOptions() for FilterSelect and FilterMultiSelect.

### DIFF
--- a/src/Filter/FilterSelect.php
+++ b/src/Filter/FilterSelect.php
@@ -44,7 +44,7 @@ class FilterSelect extends Filter
 	 * @param DataGrid $grid
 	 * @param string   $key
 	 * @param string   $name
-	 * @param string   $options
+	 * @param array    $options
 	 * @param string   $column
 	 */
 	public function __construct($grid, $key, $name, array $options, $column)
@@ -87,6 +87,15 @@ class FilterSelect extends Filter
 	{
 		$this->translateOptions = (bool) $translateOptions;
 		return $this;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function getOptions()
+	{
+		return $this->options;
 	}
 
 


### PR DESCRIPTION
If I want show filters as pills like:

```
<span class="label label-primary offset-right">
	{$filter->getName()}:
	{foreach $filter->getValue() as $value}
		{$filter->getOptions[$value]}{sep}, {/sep}
	{/foreach}
</span>
```

Now is no effective way.