### PR TITLE
Enable Nette v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -29,6 +27,14 @@ jobs:
       php: 7.1
       install:
         - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
+      script:
+        - vendor/bin/tester tests/ -c tests/php.ini
+
+    - env: title="Highest Dependencies 7.3"
+      php: 7.3
+      install:
+        - composer remove --dev tharos/leanmapper nextras/orm # Dependencies with no Nette v3 support, yet
+        - travis_retry composer update --no-progress --prefer-dist
       script:
         - vendor/bin/tester tests/ -c tests/php.ini
 

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,25 @@
 		}
 	},
 	"require": {
-		"php": "^5.6|^7.0",
-		"nette/application": "^2.4.0",
-		"nette/utils": "^2.4.0",
-		"nette/forms": "^2.3.0",
-		"ublaboo/responses": "~1.0.0 || ~2.0.0",
+		"php": "^7.1",
+		"nette/application": "^2.4.0 || ^3.0",
+		"nette/caching": "^2.5.0 || ^3.0",
+		"nette/component-model": "^2.4.0 || ^3.0",
+		"nette/http": "^2.4.0 || ^3.0",
+		"nette/utils": "^2.5 || ^3.0",
+		"nette/forms": "^2.3.0 || ^3.0",
+		"ublaboo/responses": "~1.0.7 || ~2.0.0",
 		"symfony/property-access": "^3.0.0 || ^4.0.0"
 	},
 	"require-dev": {
-		"nette/tester": "^1.6.1",
-		"tracy/tracy": "^2.3.0",
+		"nette/tester": "^2.2",
+		"latte/latte": "^2.5.1",
+		"tracy/tracy": "^2.3.0 || ^2.6.2",
 		"mockery/mockery": "~0.9",
 		"tharos/leanmapper": "~2.2.0",
 		"nextras/orm": "~2.3.0",
 		"doctrine/orm": "~2.5",
-		"nette/database": "^2.3",
+		"nette/database": "^2.4 || ^3.0",
 		"dibi/dibi": "^3.0"
 	},
 	"extra": {

--- a/src/Components/DataGridPaginator/DataGridPaginator.php
+++ b/src/Components/DataGridPaginator/DataGridPaginator.php
@@ -52,12 +52,8 @@ class DataGridPaginator extends Nette\Application\UI\Control
 
 	public function __construct(
 		Nette\Localization\ITranslator $translator,
-		$icon_prefix = 'fa fa-',
-		IContainer $parent = null,
-		$name = null
+		$icon_prefix = 'fa fa-'
 	) {
-		parent::__construct($parent, $name);
-
 		$this->translator = $translator;
 		$this->icon_prefix = $icon_prefix;
 	}
@@ -146,13 +142,7 @@ class DataGridPaginator extends Nette\Application\UI\Control
 		$this->template->render();
 	}
 
-
-	/**
-	 * Loads state informations.
-	 * @param  array
-	 * @return void
-	 */
-	public function loadState(array $params)
+	public function loadState(array $params): void
 	{
 		parent::loadState($params);
 

--- a/src/DataSource/FilterableDataSource.php
+++ b/src/DataSource/FilterableDataSource.php
@@ -27,10 +27,7 @@ abstract class FilterableDataSource
 		foreach ($filters as $filter) {
 			if ($filter->isValueSet()) {
 				if ($filter->hasConditionCallback()) {
-					Callback::invokeArgs(
-						$filter->getConditionCallback(),
-						[$this->data_source, $filter->getValue()]
-					);
+					($filter->getConditionCallback())($this->data_source, $filter->getValue());
 				} else {
 					if ($filter instanceof Filter\FilterText) {
 						$this->applyFilterText($filter);

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -51,12 +51,12 @@ class Export
 	 * @var DataGrid
 	 */
 	protected $grid;
-	
+
 	/**
 	 * @var null|string
 	 */
 	protected $confirmDialog = null;
-	
+
 	/**
 	 * @param DataGrid   $grid
 	 * @param string     $text
@@ -96,15 +96,15 @@ class Export
 		if ($this->isAjax()) {
 			$a->class[] = 'ajax';
 		}
-		
+
 		if ($this->confirmDialog !== null) {
 			$a->setAttribute('data-datagrid-confirm', $this->confirmDialog);
 		}
-		
-		
+
+
 		return $a;
 	}
-	
+
 	/**
 	 * Add Confirm dialog
 	 * @param string $confirmDialog
@@ -113,11 +113,11 @@ class Export
 	public function setConfirmDialog($confirmDialog)
 	{
 		$this->confirmDialog = $confirmDialog;
-		
+
 		return $this;
 	}
-	
-	
+
+
 	/**
 	 * Tell export which columns to use when exporting data
 	 * @param array $columns
@@ -193,6 +193,6 @@ class Export
 	 */
 	public function invoke(array $data)
 	{
-		Callback::invokeArgs($this->callback, [$data, $this->grid]);
+		call_user_func($this->callback, $data, $this->grid);
 	}
 }

--- a/src/Localization/BaseSimpleTranslator.php
+++ b/src/Localization/BaseSimpleTranslator.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright   Copyright (c) 2015 ublaboo <ublaboo@paveljanda.com>
+ * @author      Pavel Janda <me@paveljanda.com>
+ * @package     Ublaboo
+ */
+
+namespace Ublaboo\DataGrid\Localization;
+
+use Nette;
+use Nette\SmartObject;
+
+abstract class BaseSimpleTranslator implements Nette\Localization\ITranslator
+{
+
+	use SmartObject;
+
+	/**
+	 * @var array
+	 */
+	protected $dictionary = [
+		'ublaboo_datagrid.no_item_found_reset' => 'No items found. You can reset the filter',
+		'ublaboo_datagrid.no_item_found' => 'No items found.',
+		'ublaboo_datagrid.here' => 'here',
+		'ublaboo_datagrid.items' => 'Items',
+		'ublaboo_datagrid.all' => 'all',
+		'ublaboo_datagrid.from' => 'from',
+		'ublaboo_datagrid.reset_filter' => 'Reset filter',
+		'ublaboo_datagrid.group_actions' => 'Group actions',
+		'ublaboo_datagrid.show' => 'Show',
+		'ublaboo_datagrid.add' => 'Add',
+		'ublaboo_datagrid.edit' => 'Edit',
+		'ublaboo_datagrid.show_all_columns' => 'Show all columns',
+		'ublaboo_datagrid.show_default_columns' => 'Show default columns',
+		'ublaboo_datagrid.hide_column' => 'Hide column',
+		'ublaboo_datagrid.action' => 'Action',
+		'ublaboo_datagrid.previous' => 'Previous',
+		'ublaboo_datagrid.next' => 'Next',
+		'ublaboo_datagrid.choose' => 'Choose',
+		'ublaboo_datagrid.choose_input_required' => 'Group action text not allow empty value',
+		'ublaboo_datagrid.execute' => 'Execute',
+		'ublaboo_datagrid.save' => 'Save',
+		'ublaboo_datagrid.cancel' => 'Cancel',
+		'ublaboo_datagrid.multiselect_choose' => 'Choose',
+		'ublaboo_datagrid.multiselect_selected' => '{0} selected',
+		'ublaboo_datagrid.filter_submit_button' => 'Filter',
+		'ublaboo_datagrid.show_filter' => 'Show filter',
+		'ublaboo_datagrid.per_page_submit' => 'Change',
+	];
+
+
+	/**
+	 * @param array $dictionary
+	 */
+	public function __construct(array $dictionary = null)
+	{
+		if (is_array($dictionary)) {
+			$this->dictionary = $dictionary;
+		}
+	}
+
+
+	/**
+	 * Set translator dictionary
+	 * @param array $dictionary
+	 */
+	public function setDictionary(array $dictionary)
+	{
+		$this->dictionary = $dictionary;
+	}
+}

--- a/src/Localization/SimpleTranslatorNette3.php
+++ b/src/Localization/SimpleTranslatorNette3.php
@@ -11,16 +11,15 @@ namespace Ublaboo\DataGrid\Localization;
 use Nette;
 use Nette\SmartObject;
 
-class SimpleTranslator extends BaseSimpleTranslator
+class SimpleTranslatorNette3 extends BaseSimpleTranslator
 {
 
 	/**
 	 * Translates the given string
 	 *
 	 * @param  string
-	 * @param  int
 	 */
-	public function translate($message, $count = null): string
+	public function translate($message, ...$parameters): string
 	{
 		return isset($this->dictionary[$message]) ? $this->dictionary[$message] : $message;
 	}

--- a/tests/Cases/ColumnActionTest.phpt
+++ b/tests/Cases/ColumnActionTest.phpt
@@ -4,7 +4,7 @@ namespace Ublaboo\DataGrid\Tests\Cases;
 
 use Tester\TestCase;
 use Tester\Assert;
-use Mockery;
+use Ublaboo\DataGrid\Column\Action;
 use Ublaboo\DataGrid\DataGrid;
 use Ublaboo;
 
@@ -19,15 +19,22 @@ final class ColumnActionTest extends TestCase
 	 */
 	private $grid;
 
+	/**
+	 * @var string
+	 */
+	private $urlPrefix;
+
 
 	public function setUp()
 	{
 		$factory = new Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
 		$this->grid = $factory->createXTestingDataGrid();
+
+		[$this->urlPrefix] = explode('/', $this->grid->getPresenter()->link('this'));
 	}
 
 
-	public function render($column)
+	public function render(Action $column)
 	{
 		$item = new Ublaboo\DataGrid\Row($this->grid, ['id' => 1, 'name' => 'John'], 'id');
 
@@ -37,7 +44,7 @@ final class ColumnActionTest extends TestCase
 
 	public function testActionDuplcitColumn()
 	{
-		$action = $this->grid->addAction('action', 'Do', 'doStuff!');
+		$this->grid->addAction('action', 'Do', 'doStuff!');
 
 		$grid = $this->grid;
 		$add_action = function() use ($grid) {
@@ -57,20 +64,20 @@ final class ColumnActionTest extends TestCase
 		$action = $this->grid->addAction('action', 'Do', 'doStuff!');
 
 		Assert::same(
-			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary">Do</a>',
 			$this->render($action)
 		);
 
 		$action = $this->grid->addAction('detail', 'Do');
 
 		Assert::same(
-			'<a href="detail?id=1" class="btn btn-xs btn-default btn-secondary">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;action=detail&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary">Do</a>',
 			$this->render($action)
 		);
 
 		$action = $this->grid->addAction('title', 'Do', 'detail', ['id', 'name']);
 		Assert::same(
-			'<a href="detail?id=1&amp;name=John" class="btn btn-xs btn-default btn-secondary">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;name=John&amp;action=detail&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary">Do</a>',
 			$this->render($action)
 		);
 
@@ -78,7 +85,7 @@ final class ColumnActionTest extends TestCase
 			'id' => 'name', 'name' => 'id'
 		]);
 		Assert::same(
-			'<a href="detail?id=John&amp;name=1" class="btn btn-xs btn-default btn-secondary">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=John&amp;name=1&amp;action=detail&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary">Do</a>',
 			$this->render($action)
 		);
 	}
@@ -92,7 +99,7 @@ final class ColumnActionTest extends TestCase
 		$action->setIcon('user');
 
 		Assert::same(
-			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary"><span class="icon-user"></span>&nbsp;Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary"><span class="icon-user"></span>&nbsp;Do</a>',
 			$this->render($action)
 		);
 	}
@@ -102,11 +109,11 @@ final class ColumnActionTest extends TestCase
 	{
 		$action = $this->grid->addAction('action', 'Do', 'doStuff!')->setClass('btn');
 
-		Assert::same('<a href="doStuff!?id=1" class="btn">Do</a>', $this->render($action));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" class="btn">Do</a>', $this->render($action));
 
 		$action->setClass(NULL);
 
-		Assert::same('<a href="doStuff!?id=1">Do</a>', $this->render($action));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting">Do</a>', $this->render($action));
 	}
 
 
@@ -115,7 +122,7 @@ final class ColumnActionTest extends TestCase
 		$action = $this->grid->addAction('action', 'Do', 'doStuff!')->setTitle('hello');
 
 		Assert::same(
-			'<a href="doStuff!?id=1" title="hello" class="btn btn-xs btn-default btn-secondary">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" title="hello" class="btn btn-xs btn-default btn-secondary">Do</a>',
 			$this->render($action)
 		);
 	}
@@ -126,7 +133,7 @@ final class ColumnActionTest extends TestCase
 		$action = $this->grid->addAction('action', 'Do', 'doStuff!')->setConfirm('Really?');
 
 		Assert::same(
-			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary" data-datagrid-confirm="Really?">Do</a>',
+			'<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary" data-datagrid-confirm="Really?">Do</a>',
 			$this->render($action)
 		);
 	}
@@ -138,7 +145,7 @@ final class ColumnActionTest extends TestCase
 			return true;
 		});
 
-		Assert::same('<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary">Do</a>', $this->render($action));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=default&amp;do=doStuff&amp;presenter=XTesting" class="btn btn-xs btn-default btn-secondary">Do</a>', $this->render($action));
 
 		$action = $this->grid->addAction('action2', 'Do', 'doStuff!')->setRenderCondition(function () {
 			return false;

--- a/tests/Cases/ColumnLinkTest.phpt
+++ b/tests/Cases/ColumnLinkTest.phpt
@@ -5,9 +5,9 @@ namespace Ublaboo\DataGrid\Tests\Cases;
 use Tester\TestCase;
 use Tester\Assert;
 use Ublaboo;
+use Ublaboo\DataGrid\Column\ColumnLink;
 
 require __DIR__ . '/../bootstrap.php';
-require __DIR__ . '/../Files/XTestingDataGridFactory.php';
 
 final class ColumnLinkTest extends TestCase
 {
@@ -17,15 +17,21 @@ final class ColumnLinkTest extends TestCase
 	 */
 	private $grid;
 
+	/**
+	 * @var string
+	 */
+	private $urlPrefix;
 
 	public function setUp()
 	{
 		$factory = new Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
 		$this->grid = $factory->createXTestingDataGrid();
+
+		[$this->urlPrefix] = explode('/', $this->grid->getPresenter()->link('this'));
 	}
 
 
-	public function render($column)
+	public function render(ColumnLink $column)
 	{
 		$item = new Ublaboo\DataGrid\Row($this->grid, ['id' => 1, 'name' => 'John'], 'id');
 
@@ -36,42 +42,42 @@ final class ColumnLinkTest extends TestCase
 	public function testLink()
 	{
 		$link = $this->grid->addColumnLink('name', 'Href');
-		Assert::same('<a href="name?id=1">John</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=name&amp;presenter=XTesting">John</a>', $this->render($link));
 
 		$link = $this->grid->addColumnLink('name2', 'Href', 'edit', 'name');
-		Assert::same('<a href="edit?id=1">John</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=edit&amp;presenter=XTesting">John</a>', $this->render($link));
 
 		$link = $this->grid->addColumnLink('name3', 'Href', 'edit', 'id');
-		Assert::same('<a href="edit?id=1">1</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=edit&amp;presenter=XTesting">1</a>', $this->render($link));
 
 		$link = $this->grid->addColumnLink('name4', 'Href', 'edit', 'id', ['name']);
-		Assert::same('<a href="edit?name=John">1</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?name=John&amp;action=edit&amp;presenter=XTesting">1</a>', $this->render($link));
 
 		$link = $this->grid->addColumnLink('name5', 'Href', 'edit', 'id', ['name', 'id']);
-		Assert::same('<a href="edit?name=John&amp;id=1">1</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?name=John&amp;id=1&amp;action=edit&amp;presenter=XTesting">1</a>', $this->render($link));
 
 		$link = $this->grid->addColumnLink('name6', 'Href', 'edit', 'id', [
 			'name' => 'id',
 			'id' => 'name'
 		]);
-		Assert::same('<a href="edit?name=1&amp;id=John">1</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?name=1&amp;id=John&amp;action=edit&amp;presenter=XTesting">1</a>', $this->render($link));
 	}
 
 
 	public function testLinkClass()
 	{
 		$link = $this->grid->addColumnLink('name', 'Href')->setClass('btn');
-		Assert::same('<a href="name?id=1" class="btn">John</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=name&amp;presenter=XTesting" class="btn">John</a>', $this->render($link));
 
 		$link->setClass(NULL);
-		Assert::same('<a href="name?id=1">John</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=name&amp;presenter=XTesting">John</a>', $this->render($link));
 	}
 
 
 	public function testLinkTitle()
 	{
 		$link = $this->grid->addColumnLink('name', 'Href')->setTitle('Hello');
-		Assert::same('<a href="name?id=1" title="Hello">John</a>', $this->render($link));
+		Assert::same('<a href="' . $this->urlPrefix . '/?id=1&amp;action=name&amp;presenter=XTesting" title="Hello">John</a>', $this->render($link));
 	}
 
 }

--- a/tests/Cases/DataSources/BaseDataSourceTest.phpt
+++ b/tests/Cases/DataSources/BaseDataSourceTest.phpt
@@ -15,192 +15,192 @@ require __DIR__ . '/../../Files/XTestingDataGridFactory.php';
 abstract class BaseDataSourceTest extends TestCase
 {
 
-    protected $data = [
-        ['id' => 1, 'name' => 'John Doe', 'age' => 30, 'address' => 'Blue Village 1'],
-        ['id' => 2, 'name' => 'Frank Frank', 'age' => 60, 'address' => 'Yellow Garded 126'],
-        ['id' => 3, 'name' => 'Santa Claus', 'age' => 12, 'address' => 'New York'],
-        ['id' => 8, 'name' => 'Jude Law', 'age' => 8, 'address' => 'Lubababa 5'],
-        ['id' => 30, 'name' => 'Jackie Blue', 'age' => 80, 'address' => 'Prague 678'],
-        ['id' => 40, 'name' => 'John Red', 'age' => 40, 'address' => 'Porto 53'],
-    ];
+	protected $data = [
+		['id' => 1, 'name' => 'John Doe', 'age' => 30, 'address' => 'Blue Village 1'],
+		['id' => 2, 'name' => 'Frank Frank', 'age' => 60, 'address' => 'Yellow Garded 126'],
+		['id' => 3, 'name' => 'Santa Claus', 'age' => 12, 'address' => 'New York'],
+		['id' => 8, 'name' => 'Jude Law', 'age' => 8, 'address' => 'lubababa 5'],
+		['id' => 30, 'name' => 'Jackie Blue', 'age' => 80, 'address' => 'Prague 678'],
+		['id' => 40, 'name' => 'John Red', 'age' => 40, 'address' => 'Porto 53'],
+	];
 
-    /**
-     * @var Ublaboo\DataGrid\DataSource\IDataSource
-     */
-    protected $ds;
+	/**
+	 * @var Ublaboo\DataGrid\DataSource\IDataSource
+	 */
+	protected $ds;
 
-    /**
-     * @var Ublaboo\DataGrid\DataGrid
-     */
-    protected $grid;
+	/**
+	 * @var Ublaboo\DataGrid\DataGrid
+	 */
+	protected $grid;
 
-    public function testGetCount()
-    {
-        Assert::same(6, $this->ds->getCount());
-    }
+	public function testGetCount()
+	{
+		Assert::same(6, $this->ds->getCount());
+	}
 
-    public function testGetFilteredCount()
-    {
-        $filter = new FilterText($this->grid, 'a', 'b', ['name']);
-        $filter->setValue('John Red');
+	public function testGetFilteredCount()
+	{
+		$filter = new FilterText($this->grid, 'a', 'b', ['name']);
+		$filter->setValue('John Red');
 
-        $this->ds->filter([$filter]);
-        Assert::same(2, $this->ds->getCount());
-    }
+		$this->ds->filter([$filter]);
+		Assert::same(2, $this->ds->getCount());
+	}
 
-    public function testGetData()
-    {
-        Assert::equal($this->data, $this->getActualResultAsArray());
-    }
-
-
-    public function testFilterSingleColumn()
-    {
-        $filter = new FilterText($this->grid, 'a', 'b', ['name']);
-        $filter->setValue('John Red');
-
-        $this->ds->filter([$filter]);
-        Assert::equal([
-            $this->data[0],
-            $this->data[5]
-        ], $this->getActualResultAsArray());
-    }
-
-    public function testFilterMultipleColumns()
-    {
-        $filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
-        $filter->setValue('lu');
-        $this->ds->filter([$filter]);
+	public function testGetData()
+	{
+		Assert::equal($this->data, $this->getActualResultAsArray());
+	}
 
 
-        Assert::equal([
-            $this->data[0],
-            $this->data[3],
-            $this->data[4]
-        ], $this->getActualResultAsArray());
-    }
+	public function testFilterSingleColumn()
+	{
+		$filter = new FilterText($this->grid, 'a', 'b', ['name']);
+		$filter->setValue('John Red');
 
-    public function testFilterFalseSplitWordsSearch()
-    {
+		$this->ds->filter([$filter]);
+		Assert::equal([
+			$this->data[0],
+			$this->data[5]
+		], $this->getActualResultAsArray());
+	}
 
-        /**
-         * Single column - SplitWordsSearch => FALSE
-         */
-        $filter = new FilterText($this->grid, 'a', 'b', ['name']);
-        $filter->setSplitWordsSearch(FALSE);
-        $filter->setValue('John Red');
-
-        $this->ds->filter([$filter]);
-
-        Assert::equal([$this->data[5]], $this->getActualResultAsArray());
-    }
-
-    public function testFilterRangeMin()
-    {
-
-        $filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
-        $filter->setValue(['from' =>40]);
-        $this->ds->filter([$filter]);
-
-        Assert::equal([
-            $this->data[1],
-            $this->data[4],
-            $this->data[5]
-        ], $this->getActualResultAsArray());
-    }
-
-    public function testFilterRangeMax()
-    {
-
-        $filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
-        $filter->setValue(['to' => 30]);
-        $this->ds->filter([$filter]);
-
-        Assert::equal([
-            $this->data[0],
-            $this->data[2],
-            $this->data[3]
-        ], $this->getActualResultAsArray());
-    }
-
-    public function testFilterRangeMinMax()
-    {
-
-        $filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
-        $filter->setValue(['from' => 12, 'to' => 30]);
-        $this->ds->filter([$filter]);
-
-        Assert::equal([
-            $this->data[0],
-            $this->data[2]
-        ], $this->getActualResultAsArray());
-    }
-
-    public function testFilterOne()
-    {
-        $this->ds->filterOne(['id' => 8]);
-
-        Assert::equal([$this->data[3]], $this->getActualResultAsArray());
-    }
-
-    public function testFilterExactSearch(){
-
-        $filter = new FilterText($this->grid, 'a', 'b', ['name']);
-        $filter->setExactSearch();
-        $filter->setValue('John Red');
-
-        $this->ds->filter([$filter]);
-
-        Assert::equal([$this->data[5]], $this->getActualResultAsArray());
-    }
-
-    public function testFilterExactSearchId(){
-
-        $filter = new FilterText($this->grid, 'a', 'b', ['id']);
-        $filter->setExactSearch();
-        $filter->setValue('3');
-
-        $this->ds->filter([$filter]);
-
-        Assert::equal([$this->data[2]], $this->getActualResultAsArray());
-    }
-
-    public function testLimit()
-    {
-        $this->ds->limit(2, 2);
-        $result = $this->getActualResultAsArray();
-        Assert::equal([
-            $this->data[2],
-            $this->data[3]
-        ], $result);
-    }
+	public function testFilterMultipleColumns()
+	{
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setValue('lu');
+		$this->ds->filter([$filter]);
 
 
-    public function testSort()
-    {
-        $this->ds->sort(new Sorting(['name' => 'DESC']));
+		Assert::equal([
+			$this->data[0],
+			$this->data[3],
+			$this->data[4]
+		], $this->getActualResultAsArray());
+	}
 
-        $result = $this->getActualResultAsArray();
+	public function testFilterFalseSplitWordsSearch()
+	{
 
-        Assert::equal([
-            $this->data[2],
-            $this->data[3],
-            $this->data[5],
-            $this->data[0],
-            $this->data[4],
-            $this->data[1]
-        ], $result);
-    }
+		/**
+		 * Single column - SplitWordsSearch => FALSE
+		 */
+		$filter = new FilterText($this->grid, 'a', 'b', ['name']);
+		$filter->setSplitWordsSearch(FALSE);
+		$filter->setValue('John Red');
+
+		$this->ds->filter([$filter]);
+
+		Assert::equal([$this->data[5]], $this->getActualResultAsArray());
+	}
+
+	public function testFilterRangeMin()
+	{
+
+		$filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['from' =>40]);
+		$this->ds->filter([$filter]);
+
+		Assert::equal([
+			$this->data[1],
+			$this->data[4],
+			$this->data[5]
+		], $this->getActualResultAsArray());
+	}
+
+	public function testFilterRangeMax()
+	{
+
+		$filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['to' => 30]);
+		$this->ds->filter([$filter]);
+
+		Assert::equal([
+			$this->data[0],
+			$this->data[2],
+			$this->data[3]
+		], $this->getActualResultAsArray());
+	}
+
+	public function testFilterRangeMinMax()
+	{
+
+		$filter = new Ublaboo\DataGrid\Filter\FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['from' => 12, 'to' => 30]);
+		$this->ds->filter([$filter]);
+
+		Assert::equal([
+			$this->data[0],
+			$this->data[2]
+		], $this->getActualResultAsArray());
+	}
+
+	public function testFilterOne()
+	{
+		$this->ds->filterOne(['id' => 8]);
+
+		Assert::equal([$this->data[3]], $this->getActualResultAsArray());
+	}
+
+	public function testFilterExactSearch(){
+
+		$filter = new FilterText($this->grid, 'a', 'b', ['name']);
+		$filter->setExactSearch();
+		$filter->setValue('John Red');
+
+		$this->ds->filter([$filter]);
+
+		Assert::equal([$this->data[5]], $this->getActualResultAsArray());
+	}
+
+	public function testFilterExactSearchId(){
+
+		$filter = new FilterText($this->grid, 'a', 'b', ['id']);
+		$filter->setExactSearch();
+		$filter->setValue(3);
+
+		$this->ds->filter([$filter]);
+
+		Assert::equal([$this->data[2]], $this->getActualResultAsArray());
+	}
+
+	public function testLimit()
+	{
+		$this->ds->limit(2, 2);
+		$result = $this->getActualResultAsArray();
+		Assert::equal([
+			$this->data[2],
+			$this->data[3]
+		], $result);
+	}
 
 
-    protected function getActualResultAsArray()
-    {
-        return array_values(
-            json_decode(
-                json_encode($this->ds->getData())
-                , TRUE)
-        );
-    }
+	public function testSort()
+	{
+		$this->ds->sort(new Sorting(['name' => 'DESC']));
+
+		$result = $this->getActualResultAsArray();
+
+		Assert::equal([
+			$this->data[2],
+			$this->data[3],
+			$this->data[5],
+			$this->data[0],
+			$this->data[4],
+			$this->data[1]
+		], $result);
+	}
+
+
+	protected function getActualResultAsArray()
+	{
+		return array_values(
+			json_decode(
+				json_encode($this->ds->getData())
+				, TRUE)
+		);
+	}
 }
 
 Assert::true(TRUE);

--- a/tests/Cases/DataSources/NextrasDataSourceTest.phpt
+++ b/tests/Cases/DataSources/NextrasDataSourceTest.phpt
@@ -2,20 +2,20 @@
 
 namespace Ublaboo\DataGrid\Tests\Cases\DataSources;
 
+use Nette;
+use Nextras;
 use Nextras\Orm\Relationships\OneHasMany;
 use Tester\Environment;
-use Tester\TestCase;
-use Tester\Assert;
 use Ublaboo\DataGrid\DataSource\NextrasDataSource;
+use Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
 
 require __DIR__ . '/BaseDataSourceTest.phpt';
 
-// Temporary cause:
-// E_USER_DEPRECATED: Replace deprecated Nette\Object with trait Nette\SmartObject in BaseMapper
-error_reporting(E_ERROR | E_PARSE);
-
 if (!extension_loaded('mysqli')) {
-    \Tester\Environment::skip('Test requires MySQLi extension to be loaded.');
+	Environment::skip('Test requires MySQLi extension to be loaded.');
+}
+if (!class_exists('Nextras\Orm\Entity\Entity')) {
+	Environment::skip('Test requires Nextras\Orm dependency.');
 }
 
 /**
@@ -23,23 +23,23 @@ if (!extension_loaded('mysqli')) {
  */
 final class NextrasDataSourceTest extends BaseDataSourceTest {
 
-	/** @var \Nextras\Orm\Model\Model */
+	/** @var Nextras\Orm\Model\Model */
 	private $model;
 
 	public function setUp() {
 		$this->setUpDatabase();
 
 		$this->ds = new NextrasDataSource($this->model->users->findAll(), 'id');
-		$factory = new \Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
+		$factory = new XTestingDataGridFactory;
 		$this->grid = $factory->createXTestingDataGrid();
 	}
 
 	protected function setUpDatabase() {
-		$args = \Tester\Environment::loadData();
+		$args = Environment::loadData();
 
-		$storage = new \Nette\Caching\Storages\DevNullStorage();
-		$cache = new \Nette\Caching\Cache($storage);
-		$connection = new \Nextras\Dbal\Connection($args);
+		$storage = new Nette\Caching\Storages\DevNullStorage();
+		$cache = new Nette\Caching\Cache($storage);
+		$connection = new Nextras\Dbal\Connection($args);
 
 		$connection->query("DROP TABLE IF EXISTS `users`");
 		$connection->query("CREATE TABLE `users` (
@@ -50,7 +50,7 @@ final class NextrasDataSourceTest extends BaseDataSourceTest {
 								PRIMARY KEY (`id`)
 							) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_czech_ci;");
 
-		$simpleModelFactory = new \Nextras\Orm\Model\SimpleModelFactory($cache, [
+		$simpleModelFactory = new Nextras\Orm\Model\SimpleModelFactory($cache, [
 			'users' => new UsersRepository(new UsersMapper($connection, $cache)),
 		]);
 
@@ -71,7 +71,7 @@ final class NextrasDataSourceTest extends BaseDataSourceTest {
 
 /**
  * User
- * 
+ *
  * @property int $id {primary}
  * @property string $name
  * @property int $age

--- a/tests/Cases/ExportLinkTest.phpt
+++ b/tests/Cases/ExportLinkTest.phpt
@@ -18,6 +18,7 @@ final class ExportLinkTest extends TestCase
 	public function testExportLink()
 	{
 		$factory = new XTestingDataGridFactory;
+		/** @var Ublaboo\DataGrid\DataGrid $grid */
 		$grid = $factory->createXTestingDataGrid('ExportTesting');
 		$grid->setDataSource([]);
 

--- a/tests/Cases/ExportTest.phpt
+++ b/tests/Cases/ExportTest.phpt
@@ -58,10 +58,9 @@ final class ExportTest extends TestCase
 			Assert::same($data, $source);
 		};
 
-		$export = $this->grid->addExportCallback('Export', $callback);
+		$this->grid->addExportCallback('Export', $callback);
 
-		$grid = $this->grid;
-		$trigger = function() use ($grid) {
+		$trigger = function() {
 			$this->grid->handleExport(1);
 		};
 
@@ -85,12 +84,11 @@ final class ExportTest extends TestCase
 			Assert::same($data, $source);
 		};
 
-		$export = $this->grid->addExportCallback('Export', $callback, TRUE);
+		$this->grid->addExportCallback('Export', $callback, TRUE);
 
 		$this->grid->addFilterText('name', 'Name');
 
-		$grid = $this->grid;
-		$trigger = function() use ($grid) {
+		$trigger = function() {
 			$this->grid->handleExport(1);
 		};
 

--- a/tests/Cases/RowTest.phpt
+++ b/tests/Cases/RowTest.phpt
@@ -3,14 +3,15 @@
 namespace Ublaboo\DataGrid\Tests\Cases;
 
 use Nette\Utils\Html;
+use Tester\Environment;
 use Tester\TestCase;
 use Tester\Assert;
 use Ublaboo;
-use Nette\SmartObject;
-use LeanMapper;
+use Ublaboo\DataGrid\Tests\Files\XTestingDDataGridEntity;
+use Ublaboo\DataGrid\Tests\Files\XTestingLMDataGridEntity;
+use Ublaboo\DataGrid\Tests\Files\XTestingLMDataGridEntity2;
 
 require __DIR__ . '/../bootstrap.php';
-require __DIR__ . '/../Files/XTestingDataGridFactory.php';
 
 final class RowTest extends TestCase
 {
@@ -64,21 +65,6 @@ final class RowTest extends TestCase
 	}
 
 
-	public function testLeanMapperEntity()
-	{
-		$entity = new XTestingLMDataGridEntity(['id' => 20, 'name' => 'John Doe', 'age' => 23]);
-		$entity2 = new XTestingLMDataGridEntity2(['id' => 21, 'name' => 'Francis', 'age' => 20]);
-
-		$entity->setGirlfriend($entity2);
-
-		$row = new Ublaboo\DataGrid\Row($this->grid, $entity, 'id');
-
-		Assert::same('John Doe', $row->getValue('name'));
-		Assert::same(23, $row->getValue('age'));
-		Assert::same(20, $row->getValue('girlfriend.age'));
-	}
-
-
 	public function testDoctrineEntity()
 	{
 		$entity = new XTestingDDataGridEntity(['id' => 20, 'name' => 'John Doe', 'age' => 23]);
@@ -94,124 +80,23 @@ final class RowTest extends TestCase
 		Assert::same(20, $row->getValue('partner.age'));
 	}
 
-}
 
-
-/**
- * @property int $id
- * @property string $name
- * @property XTestingLMDataGridEntity2|NULL $girlfriend
- */
-class XTestingLMDataGridEntity extends LeanMapper\Entity
-{
-
-	private $age;
-
-
-	public function getAge()
+	public function testLeanMapperEntity()
 	{
-		return $this->age;
-	}
+		if (!class_exists('LeanMapper\Entity')) {
+			Environment::skip('Test requires LeanMapper dependency.');
+		}
 
+		$entity = new XTestingLMDataGridEntity(['id' => 20, 'name' => 'John Doe', 'age' => 23]);
+		$entity2 = new XTestingLMDataGridEntity2(['id' => 21, 'name' => 'Francis', 'age' => 20]);
 
-	public function setAge($age)
-	{
-		$this->age = $age;
-	}
+		$entity->setGirlfriend($entity2);
 
-}
+		$row = new Ublaboo\DataGrid\Row($this->grid, $entity, 'id');
 
-
-/**
- * @property int $id
- * @property string $name
- */
-class XTestingLMDataGridEntity2 extends LeanMapper\Entity
-{
-
-	private $age;
-
-
-	public function getAge()
-	{
-		return $this->age;
-	}
-
-
-	public function setAge($age)
-	{
-		$this->age = $age;
-	}
-
-}
-
-
-class XTestingDDataGridEntity
-{
-
-	use SmartObject;
-
-	/**
-	 * @ORM\Id
-	 * @ORM\Column(type="integer")
-	 * @ORM\GeneratedValue
-	 * @var integer
-	 */
-	private $id;
-
-	/**
-	 * @ORM\Column(type="string")
-	 * @var string
-	 */
-	private $name;
-
-	/**
-	 * @ORM\Column(type="integer")
-	 * @var integer
-	 */
-	private $age;
-
-	private $partner;
-
-
-	public function __construct($args)
-	{
-		$this->id = $args['id'];
-		$this->age = $args['age'];
-		$this->name = $args['name'];
-	}
-
-
-	public function getName()
-	{
-		return $this->name;
-	}
-
-
-	/**
-	 * @return integer
-	 */
-	final public function getId()
-	{
-		return $this->id;
-	}
-
-
-	public function getAge()
-	{
-		return $this->age;
-	}
-
-
-	public function setPartner($p)
-	{
-		$this->partner = $p;
-	}
-
-
-	public function getPartner()
-	{
-		return $this->partner;
+		Assert::same('John Doe', $row->getValue('name'));
+		Assert::same(23, $row->getValue('age'));
+		Assert::same(20, $row->getValue('girlfriend.age'));
 	}
 
 }

--- a/tests/Files/TestPresenter.php
+++ b/tests/Files/TestPresenter.php
@@ -2,16 +2,13 @@
 
 namespace Ublaboo\DataGrid\Tests\Files;
 
-final class TestPresenter extends \Nette\Application\UI\Presenter
+use Nette\Application\UI\Presenter;
+
+final class TestPresenter extends Presenter
 {
 
 	protected function createComponentGrid()
 	{
 		return new TestGridControl();
 	}
-
-	protected function createTemplate($class = null)
-	{
-	}
-
 }

--- a/tests/Files/XTestingDDataGridEntity.php
+++ b/tests/Files/XTestingDDataGridEntity.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\Tests\Files;
+
+use Nette\SmartObject;
+
+class XTestingDDataGridEntity
+{
+
+	use SmartObject;
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column(type="integer")
+	 * @ORM\GeneratedValue
+	 * @var integer
+	 */
+	private $id;
+
+	/**
+	 * @ORM\Column(type="string")
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * @ORM\Column(type="integer")
+	 * @var integer
+	 */
+	private $age;
+
+	private $partner;
+
+
+	public function __construct($args)
+	{
+		$this->id = $args['id'];
+		$this->age = $args['age'];
+		$this->name = $args['name'];
+	}
+
+
+	public function getName()
+	{
+		return $this->name;
+	}
+
+
+	/**
+	 * @return integer
+	 */
+	final public function getId()
+	{
+		return $this->id;
+	}
+
+
+	public function getAge()
+	{
+		return $this->age;
+	}
+
+
+	public function setPartner($p)
+	{
+		$this->partner = $p;
+	}
+
+
+	public function getPartner()
+	{
+		return $this->partner;
+	}
+
+}

--- a/tests/Files/XTestingDataGridFactory.php
+++ b/tests/Files/XTestingDataGridFactory.php
@@ -2,25 +2,29 @@
 
 namespace Ublaboo\DataGrid\Tests\Files;
 
-use Nette\Http,
-	Nette;
+use Nette\Application\Routers\SimpleRouter;
+use Nette\Http;
+use Nette\Application\PresenterFactory;
 
 class XTestingDataGridFactory
 {
 
 	public function createXTestingDataGrid($presenterName = 'XTesting')
 	{
-		$presenterFactory = new Nette\Application\PresenterFactory;
+		$presenterFactory = new PresenterFactory;
 		$presenterFactory->setMapping(['*' => 'Ublaboo\DataGrid\Tests\Files\*Presenter']);
 
+		/* @var XTestingPresenter $presenter */
 		$presenter = $presenterFactory->createPresenter($presenterName);
+		$presenter->setParent(null, $presenterName);
+		$presenter->changeAction('default');
 
-		$url = new Http\UrlScript('localhost');
+		$url = new Http\UrlScript('http://localhost/');
 		$request = new Http\Request($url);
 		$response = new Http\Response;
 		$session = new Http\Session($request, $response);
 
-		$presenter->injectPrimary(NULL, NULL, NULL, $request, $response, $session);
+		$presenter->injectPrimary(NULL, NULL, new SimpleRouter, $request, $response, $session);
 
 		return $presenter->getComponent('grid');
 	}

--- a/tests/Files/XTestingDataGridFactoryRouter.php
+++ b/tests/Files/XTestingDataGridFactoryRouter.php
@@ -2,30 +2,51 @@
 
 namespace Ublaboo\DataGrid\Tests\Files;
 
-use Nette\Http,
-	Nette;
+use Latte;
+use Nette\Application\PresenterFactory;
+use Nette\Application\Request;
+use Nette\Application\Routers\SimpleRouter;
+use Nette\Bridges\ApplicationLatte\ILatteFactory;
+use Nette\Bridges\ApplicationLatte\TemplateFactory;
+use Nette\Http;
 
 class XTestingDataGridFactoryRouter
 {
 
 	public function createXTestingDataGrid()
 	{
-		$presenterFactory = new Nette\Application\PresenterFactory;
+		$presenterFactory = new PresenterFactory;
 		$presenterFactory->setMapping(['*' => 'Ublaboo\DataGrid\Tests\Files\*Presenter']);
 
 		$presenter = $presenterFactory->createPresenter('Test');
 
 		$url = new Http\UrlScript('http://localhost/index.php');
-		$url->setScriptPath('/index.php');
+		if (method_exists($url, 'setScriptPath')) {
+			$url->setScriptPath('/index.php');
+		}
 		$request = new Http\Request($url);
 		$response = new Http\Response;
 		$session = new Http\Session($request, $response);
 
 		$presenter->autoCanonicalize = false;
 
-		$presenter->injectPrimary(NULL, $presenterFactory, new Nette\Application\Routers\SimpleRouter, $request, $response, $session);
+		$templateFactory = new TemplateFactory(new class implements ILatteFactory {
+			private $engine;
 
-		$presenter->run(new \Nette\Application\Request('Test', Http\Request::GET, []));
+			public function __construct()
+			{
+				$this->engine = new Latte\Engine;
+			}
+
+			function create() : Latte\Engine
+			{
+				return $this->engine;
+			}
+		});
+
+		$presenter->injectPrimary(NULL, $presenterFactory, new SimpleRouter, $request, $response, $session, null, $templateFactory);
+
+		$presenter->run(new Request('Test', Http\Request::GET, []));
 
 		return $presenter->getComponent('grid');
 	}

--- a/tests/Files/XTestingLMDataGridEntity.php
+++ b/tests/Files/XTestingLMDataGridEntity.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\Tests\Files;
+
+use LeanMapper;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property XTestingLMDataGridEntity2|NULL $girlfriend
+ */
+class XTestingLMDataGridEntity extends LeanMapper\Entity
+{
+
+	private $age;
+
+
+	public function getAge()
+	{
+		return $this->age;
+	}
+
+
+	public function setAge($age)
+	{
+		$this->age = $age;
+	}
+
+}

--- a/tests/Files/XTestingLMDataGridEntity2.php
+++ b/tests/Files/XTestingLMDataGridEntity2.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\Tests\Files;
+
+use LeanMapper;
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class XTestingLMDataGridEntity2 extends LeanMapper\Entity
+{
+
+	private $age;
+
+
+	public function getAge()
+	{
+		return $this->age;
+	}
+
+
+	public function setAge($age)
+	{
+		$this->age = $age;
+	}
+
+}

--- a/tests/Files/XTestingPresenter.php
+++ b/tests/Files/XTestingPresenter.php
@@ -13,22 +13,17 @@ final class XTestingPresenter extends Nette\Application\UI\Presenter
 	 */
 	public $action_handeled = FALSE;
 
+	public function __construct()
+	{
+		parent::__construct();
+
+		$this->saveGlobalState();
+	}
+
 
 	public function handleDoStuff($id)
 	{
 		$this->action_handeled = TRUE;
-	}
-
-
-	public function link($destination, $args = array())
-	{
-		return $destination . '?' . http_build_query($args);
-	}
-
-
-	protected function createRequest($component, $destination, array $args, $mode)
-	{
-		return ucFirst($component->getName()) . $this->link($destination, $args);
 	}
 
 	protected function createComponentGrid($name)


### PR DESCRIPTION
BC Break? Probably

It relaxes dependencies to enable Nette v3 dependencies. To keep Nette v3 support relatively easy it drops <PHP 7.1 support. Also, it sets minimal Nette dependencies after Object to SmartObject switch.