### PR TITLE
Handle the invalid date values in the date and date range filters

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -9,6 +9,7 @@ use Dibi\Fluent;
 use ReflectionClass;
 use Ublaboo\DataGrid\AggregationFunction\IAggregatable;
 use Ublaboo\DataGrid\AggregationFunction\IAggregationFunction;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter\FilterDate;
 use Ublaboo\DataGrid\Filter\FilterDateRange;
 use Ublaboo\DataGrid\Filter\FilterMultiSelect;
@@ -132,9 +133,13 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->dataSource->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+			$this->dataSource->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 
@@ -146,17 +151,25 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 		$valueTo = $conditions[$filter->getColumn()]['to'];
 
 		if ($valueFrom) {
-			$dateFrom = DateTimeHelper::tryConvertToDateTime($valueFrom, [$filter->getPhpFormat()]);
-			$dateFrom->setTime(0, 0, 0);
+			try {
+				$dateFrom = DateTimeHelper::tryConvertToDateTime($valueFrom, [$filter->getPhpFormat()]);
+				$dateFrom->setTime(0, 0, 0);
 
-			$this->dataSource->where('DATE(%n) >= ?', $filter->getColumn(), $dateFrom);
+				$this->dataSource->where('DATE(%n) >= ?', $filter->getColumn(), $dateFrom);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($valueTo) {
-			$dateTo = DateTimeHelper::tryConvertToDateTime($valueTo, [$filter->getPhpFormat()]);
-			$dateTo->setTime(23, 59, 59);
+			try {
+				$dateTo = DateTimeHelper::tryConvertToDateTime($valueTo, [$filter->getPhpFormat()]);
+				$dateTo->setTime(23, 59, 59);
 
-			$this->dataSource->where('DATE(%n) <= ?', $filter->getColumn(), $dateTo);
+				$this->dataSource->where('DATE(%n) <= ?', $filter->getColumn(), $dateTo);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 

--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -7,6 +7,7 @@ namespace Ublaboo\DataGrid\DataSource;
 use Dibi;
 use Dibi\Fluent;
 use Dibi\Result;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter\FilterDate;
 use Ublaboo\DataGrid\Filter\FilterDateRange;
 use Ublaboo\DataGrid\Filter\FilterText;
@@ -73,16 +74,20 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime(
-			$conditions[$filter->getColumn()],
-			[$filter->getPhpFormat()]
-		);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime(
+				$conditions[$filter->getColumn()],
+				[$filter->getPhpFormat()]
+			);
 
-		$this->dataSource->where(
-			'CONVERT(varchar(10), %n, 112) = ?',
-			$filter->getColumn(),
-			$date->format('Ymd')
-		);
+			$this->dataSource->where(
+				'CONVERT(varchar(10), %n, 112) = ?',
+				$filter->getColumn(),
+				$date->format('Ymd')
+			);
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 

--- a/src/DataSource/NetteDatabaseTableMssqlDataSource.php
+++ b/src/DataSource/NetteDatabaseTableMssqlDataSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ublaboo\DataGrid\DataSource;
 
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter\FilterDate;
 use Ublaboo\DataGrid\Filter\FilterDateRange;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
@@ -15,12 +16,16 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->dataSource->where(
-			"CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
-			$date->format('Ymd')
-		);
+			$this->dataSource->where(
+				"CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
+				$date->format('Ymd')
+			);
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 
@@ -32,23 +37,31 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 		$valueTo = $conditions[$filter->getColumn()]['to'];
 
 		if ($valueFrom) {
-			$dateFrom = DateTimeHelper::tryConvertToDateTime($valueFrom, [$filter->getPhpFormat()]);
-			$dateFrom->setTime(0, 0, 0);
+			try {
+				$dateFrom = DateTimeHelper::tryConvertToDateTime($valueFrom, [$filter->getPhpFormat()]);
+				$dateFrom->setTime(0, 0, 0);
 
-			$this->dataSource->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
-				$dateFrom->format('Ymd')
-			);
+				$this->dataSource->where(
+					"CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
+					$dateFrom->format('Ymd')
+				);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($valueTo) {
-			$dateTo = DateTimeHelper::tryConvertToDateTime($valueTo, [$filter->getPhpFormat()]);
-			$dateTo->setTime(23, 59, 59);
+			try {
+				$dateTo = DateTimeHelper::tryConvertToDateTime($valueTo, [$filter->getPhpFormat()]);
+				$dateTo->setTime(23, 59, 59);
 
-			$this->dataSource->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
-				$dateTo->format('Ymd')
-			);
+				$this->dataSource->where(
+					"CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
+					$dateTo->format('Ymd')
+				);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 }


### PR DESCRIPTION
Handle the invalid date values in the date and date range filters. Do not apply the filter when the date string is invalid (DataGridDateTimeHelperException is thrown).