### PR TITLE
Handle the invalid date values in the date and date range filters - v5.x version

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -11,6 +11,7 @@ namespace Ublaboo\DataGrid\DataSource;
 use Dibi;
 use DibiFluent;
 use Ublaboo\DataGrid\AggregationFunction\IAggregatable;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 use Ublaboo\DataGrid\Utils\Sorting;
@@ -92,9 +93,13 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->data_source->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+			$this->data_source->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 
@@ -111,17 +116,25 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 		$value_to = $conditions[$filter->getColumn()]['to'];
 
 		if ($value_from) {
-			$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
-			$date_from->setTime(0, 0, 0);
+			try {
+				$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where('DATE(%n) >= ?', $filter->getColumn(), $date_from);
+				$this->data_source->where('DATE(%n) >= ?', $filter->getColumn(), $date_from);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($value_to) {
-			$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
-			$date_to->setTime(23, 59, 59);
+			try {
+				$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where('DATE(%n) <= ?', $filter->getColumn(), $date_to);
+				$this->data_source->where('DATE(%n) <= ?', $filter->getColumn(), $date_to);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 

--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -10,6 +10,7 @@ namespace Ublaboo\DataGrid\DataSource;
 
 use Dibi;
 use DibiFluent;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 
@@ -83,9 +84,13 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->data_source->where('CONVERT(varchar(10), %n, 112) = ?', $filter->getColumn(), $date->format('Ymd'));
+			$this->data_source->where('CONVERT(varchar(10), %n, 112) = ?', $filter->getColumn(), $date->format('Ymd'));
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 

--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Nette\Utils\Strings;
 use Ublaboo\DataGrid\AggregationFunction\IAggregatable;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 use Ublaboo\DataGrid\Utils\Sorting;
@@ -170,12 +171,16 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource, IA
 		$p2 = $this->getPlaceholder();
 
 		foreach ($filter->getCondition() as $column => $value) {
-			$date = DateTimeHelper::tryConvertToDateTime($value, [$filter->getPhpFormat()]);
-			$c = $this->checkAliases($column);
+			try {
+				$date = DateTimeHelper::tryConvertToDateTime($value, [$filter->getPhpFormat()]);
+				$c = $this->checkAliases($column);
 
-			$this->data_source->andWhere("$c >= :$p1 AND $c <= :$p2")
-				->setParameter($p1, $date->format('Y-m-d 00:00:00'))
-				->setParameter($p2, $date->format('Y-m-d 23:59:59'));
+				$this->data_source->andWhere("$c >= :$p1 AND $c <= :$p2")
+					->setParameter($p1, $date->format('Y-m-d 00:00:00'))
+					->setParameter($p2, $date->format('Y-m-d 23:59:59'));
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 
@@ -193,21 +198,29 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource, IA
 		$value_to = $conditions[$filter->getColumn()]['to'];
 
 		if ($value_from) {
-			$date_from = DateTimeHelper::tryConvertToDate($value_from, [$filter->getPhpFormat()]);
-			$date_from->setTime(0, 0, 0);
+			try {
+				$date_from = DateTimeHelper::tryConvertToDate($value_from, [$filter->getPhpFormat()]);
+				$date_from->setTime(0, 0, 0);
 
-			$p = $this->getPlaceholder();
+				$p = $this->getPlaceholder();
 
-			$this->data_source->andWhere("$c >= :$p")->setParameter($p, $date_from->format('Y-m-d H:i:s'));
+				$this->data_source->andWhere("$c >= :$p")->setParameter($p, $date_from->format('Y-m-d H:i:s'));
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($value_to) {
-			$date_to = DateTimeHelper::tryConvertToDate($value_to, [$filter->getPhpFormat()]);
-			$date_to->setTime(23, 59, 59);
+			try {
+				$date_to = DateTimeHelper::tryConvertToDate($value_to, [$filter->getPhpFormat()]);
+				$date_to->setTime(23, 59, 59);
 
-			$p = $this->getPlaceholder();
+				$p = $this->getPlaceholder();
 
-			$this->data_source->andWhere("$c <= :$p")->setParameter($p, $date_to->format('Y-m-d H:i:s'));
+				$this->data_source->andWhere("$c <= :$p")->setParameter($p, $date_to->format('Y-m-d H:i:s'));
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 

--- a/src/DataSource/NetteDatabaseTableDataSource.php
+++ b/src/DataSource/NetteDatabaseTableDataSource.php
@@ -10,6 +10,7 @@ namespace Ublaboo\DataGrid\DataSource;
 
 use Nette\Database\Table\Selection;
 use Nette\Utils\Strings;
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 use Ublaboo\DataGrid\Utils\Sorting;
@@ -114,9 +115,13 @@ class NetteDatabaseTableDataSource extends FilterableDataSource implements IData
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->data_source->where("DATE({$filter->getColumn()}) = ?", $date->format('Y-m-d'));
+			$this->data_source->where("DATE({$filter->getColumn()}) = ?", $date->format('Y-m-d'));
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 
@@ -133,17 +138,25 @@ class NetteDatabaseTableDataSource extends FilterableDataSource implements IData
 		$value_to = $conditions[$filter->getColumn()]['to'];
 
 		if ($value_from) {
-			$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
-			$date_from->setTime(0, 0, 0);
+			try {
+				$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where("DATE({$filter->getColumn()}) >= ?", $date_from->format('Y-m-d'));
+				$this->data_source->where("DATE({$filter->getColumn()}) >= ?", $date_from->format('Y-m-d'));
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($value_to) {
-			$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
-			$date_to->setTime(23, 59, 59);
+			try {
+				$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where("DATE({$filter->getColumn()}) <= ?", $date_to->format('Y-m-d'));
+				$this->data_source->where("DATE({$filter->getColumn()}) <= ?", $date_to->format('Y-m-d'));
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 

--- a/src/DataSource/NetteDatabaseTableMssqlDataSource.php
+++ b/src/DataSource/NetteDatabaseTableMssqlDataSource.php
@@ -8,6 +8,7 @@
 
 namespace Ublaboo\DataGrid\DataSource;
 
+use Ublaboo\DataGrid\Exception\DataGridDateTimeHelperException;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
 
@@ -23,12 +24,16 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 	{
 		$conditions = $filter->getCondition();
 
-		$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
 
-		$this->data_source->where(
-			"CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
-			$date->format('Ymd')
-		);
+			$this->data_source->where(
+				"CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
+				$date->format('Ymd')
+			);
+		} catch (DataGridDateTimeHelperException $ex) {
+			// ignore the invalid filter value
+		}
 	}
 
 
@@ -45,23 +50,31 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 		$value_to = $conditions[$filter->getColumn()]['to'];
 
 		if ($value_from) {
-			$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
-			$date_from->setTime(0, 0, 0);
+			try {
+				$date_from = DateTimeHelper::tryConvertToDateTime($value_from, [$filter->getPhpFormat()]);
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
-				$date_from->format('Ymd')
-			);
+				$this->data_source->where(
+					"CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
+					$date_from->format('Ymd')
+				);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 
 		if ($value_to) {
-			$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
-			$date_to->setTime(23, 59, 59);
+			try {
+				$date_to = DateTimeHelper::tryConvertToDateTime($value_to, [$filter->getPhpFormat()]);
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
-				$date_to->format('Ymd')
-			);
+				$this->data_source->where(
+					"CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
+					$date_to->format('Ymd')
+				);
+			} catch (DataGridDateTimeHelperException $ex) {
+				// ignore the invalid filter value
+			}
 		}
 	}
 }


### PR DESCRIPTION
Handle the invalid date values in the date and date range filters. Do not apply the filter when the date string is invalid (DataGridDateTimeHelperException is thrown).

v5.x version of https://github.com/contributte/datagrid/pull/776