### PR TITLE
Fix typeError

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2036,7 +2036,7 @@ s	 */
 			$this->deleteSessionData('_grid_has_sorted');
 		}
 
-		foreach (array_keys($this->getSessionData()) as $key) {
+		foreach ($this->getSessionData() as $key => $val) {
 			if (!in_array($key, [
 				'_grid_perPage',
 				'_grid_sort',


### PR DESCRIPTION
array_keys() expects parameter 1 to be array, object given

Doc: https://doc.nette.org/en/3.0/sessions#toc-sections
At the end of the paragraph