### PR TITLE
Render condition on status column

### DIFF
--- a/src/Column/ColumnStatus.php
+++ b/src/Column/ColumnStatus.php
@@ -10,6 +10,7 @@ use Ublaboo\DataGrid\Exception\DataGridColumnStatusException;
 use Ublaboo\DataGrid\Row;
 use Ublaboo\DataGrid\Status\Option;
 use Ublaboo\DataGrid\Traits\TButtonCaret;
+use Ublaboo\DataGrid\Traits\TRenderCondition;
 
 /**
  * @method onChange(string $id, string $value)
@@ -19,6 +20,7 @@ class ColumnStatus extends Column
 
 	use TButtonCaret;
 	use SmartObject;
+	use TRenderCondition;
 
 	/**
 	 * @var array|callable[]

--- a/src/templates/column_status.latte
+++ b/src/templates/column_status.latte
@@ -7,10 +7,14 @@
 
 <div class="dropdown">
 	{if $activeOption}
-		<button class="dropdown-toggle {$activeOption->getClass()} {$activeOption->getClassSecondary()}" type="button" data-toggle="dropdown">
-			{if $activeOption->getIcon()}<i class="{$iconPrefix}{$activeOption->getIcon()}"></i> {/if}
-			{$activeOption->getText()|translate} <i n:if="$status->hasCaret()" class="caret"></i>
-		</button>
+		{if $status->shouldBeRendered($row)}
+			<button class="dropdown-toggle {$activeOption->getClass()} {$activeOption->getClassSecondary()}" type="button" data-toggle="dropdown">
+				{if $activeOption->getIcon()}<i class="{$iconPrefix}{$activeOption->getIcon()}"></i> {/if}
+				{$activeOption->getText()|translate} <i n:if="$status->hasCaret()" class="caret"></i>
+			</button>
+		{else}
+			{$active_option->getText()|translate}
+		{/if}
 	{else}
 		{$row->getValue($status->getColumn())}
 	{/if}


### PR DESCRIPTION
This PR adds ability to restrict rendering of status column (eg. on rows without proper permission).

Renders only text, without interactive button, if condition is not met.
