### PR TITLE
Handle DataGrid::getSessionData returning plain array

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -3080,7 +3080,7 @@ class DataGrid extends Control
 
 		return $this->componentFullName;
 	}
-	
+
 
 	/**
 	 * Tell grid filters to by submitted automatically

--- a/tests/Cases/DataGridTest.phpt
+++ b/tests/Cases/DataGridTest.phpt
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\Tests\Cases;
+
+require __DIR__ . '/../bootstrap.php';
+
+use Nette\Application\AbortException;
+use Tester\Assert;
+use Tester\TestCase;
+use Ublaboo\DataGrid\DataGrid;
+use Ublaboo\DataGrid\Tests\Files\TestingDataGridFactoryRouter;
+
+final class DataGridTest extends TestCase
+{
+
+	public function testResetFilterLinkWithRememberOption(): void
+	{
+		$factory = new TestingDataGridFactoryRouter();
+		/** @var DataGrid $grid */
+		$grid = $factory->createTestingDataGrid()->getComponent('grid');
+		$grid->setRememberState(true);
+
+		Assert::exception(function() use ($grid): void {
+			$grid->handleResetFilter();
+		}, AbortException::class);
+	}
+
+	public function testResetFilterLinkWithNoRememberOption(): void
+	{
+		$factory = new TestingDataGridFactoryRouter();
+		/** @var DataGrid $grid */
+		$grid = $factory->createTestingDataGrid()->getComponent('grid');
+		$grid->setRememberState(false);
+
+		Assert::exception(function() use ($grid): void {
+			$grid->handleResetFilter();
+		}, AbortException::class);
+	}
+
+}
+
+(new DataGridTest)->run();


### PR DESCRIPTION
DataGrid with `$rememberState = false` may returns plain array from `getSessionData` and not only `Traversable`. This produce an error calling `handleResetFilter`.

This PR solves the issue and introduce missing tests.