### PR TITLE
CreateComponent bubbles to parent component

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -3313,4 +3313,16 @@ class DataGrid extends Control
 		return $presenter;
 	}
 
+	
+	protected function createComponent(string $name): ?\Nette\ComponentModel\IComponent
+	{
+		$control = parent::createComponent($name);
+
+		if ($control === null && $this->parent !== null) {
+			return $this->getParentComponent()->createComponent($name);
+		}
+
+		return $control;
+	}
+
 }


### PR DESCRIPTION
Feature
BC break - probably not

I added createComponent($name) method, which bubbles to parent if component is not found in current class.

This change is useful eg to include component into itemDetail and/or other templates. Templates belong to Datagrid, so there is current no way to use {control} macro in templates without overriding Datagrid.