### PR TITLE
Make the $template parameter nullable in Column::setTemplate()

### DIFF
--- a/src/Column/Column.php
+++ b/src/Column/Column.php
@@ -289,7 +289,7 @@ abstract class Column extends FilterableColumn
 	 *
 	 * @return static
 	 */
-	public function setTemplate(string $template, array $templateVariables = []): self
+	public function setTemplate(?string $template, array $templateVariables = []): self
 	{
 		$this->template = $template;
 		$this->templateVariables = $templateVariables;


### PR DESCRIPTION
Lets you turn off the template for columns with a default template.