### PR TITLE
Pass UI and event into nette ajax call

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -233,8 +233,9 @@ datagridSortable = function() {
 		items: 'tr',
 		axis: 'y',
 		update: function(event, ui) {
-			var component_prefix, data, item_id, next_id, prev_id, row, url;
+			var component_prefix, data, item_id, next_id, prev_id, row, url, handle;
 			row = ui.item.closest('tr[data-id]');
+			handle = ui.item.find('.handle-sort');
 			item_id = row.data('id');
 			prev_id = null;
 			next_id = null;
@@ -261,7 +262,7 @@ datagridSortable = function() {
 				error: function(jqXHR, textStatus, errorThrown) {
 					return alert(jqXHR.statusText);
 				}
-			});
+			}, handle, event);
 		},
 		helper: function(e, ui) {
 			ui.children().each(function() {
@@ -287,9 +288,10 @@ if (typeof datagridSortableTree === 'undefined') {
 			toleranceElement: '> .datagrid-tree-item-content',
 			connectWith: '.datagrid-tree-item-children',
 			update: function(event, ui) {
-				var component_prefix, data, item_id, next_id, parent, parent_id, prev_id, row, url;
+				var component_prefix, data, item_id, next_id, parent, parent_id, prev_id, row, url, handle;
 				$('.toggle-tree-to-delete').remove();
 				row = ui.item.closest('.datagrid-tree-item[data-id]');
+				handle = ui.item.find('.handle-sort');
 				item_id = row.data('id');
 				prev_id = null;
 				next_id = null;
@@ -332,7 +334,7 @@ if (typeof datagridSortableTree === 'undefined') {
 							return alert(jqXHR.statusText);
 						}
 					}
-				});
+				}, handle, event);
 			},
 			stop: function(event, ui) {
 				return $('.toggle-tree-to-delete').removeClass('toggle-tree-to-delete');

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -297,7 +297,7 @@
 													{/if}
 												{/if}
 											{/foreach}
-											<span class="handle-sort btn btn-xs btn-default btn-secondary" n:if="$control->isSortable()">
+											<span class="handle-sort btn btn-xs btn-default btn-secondary" data-ajax-pass="true" n:if="$control->isSortable()">
 												<i n:block="icon-arrows-v" class="{$iconPrefix}arrows-v {$iconPrefix}arrows-alt-v"></i>
 											</span>
 											{if $inlineEdit && $row->hasInlineEdit()}


### PR DESCRIPTION
`settings.nette` object built in `nette.ajax.js` requires UI and event to be passed. Otherwise, there is no `settings.nette` available in nette extensions. This commit changes `$.nette.ajax()` calls in sortable callbacks so the handle is passed as UI and sortable event as event. Thanks to this, it is possible to eg. make spinner work when sorting is being processed.