### PR TITLE
Add posibility to override/extend html class for the containing div

### DIFF
--- a/.docs/template.md
+++ b/.docs/template.md
@@ -76,7 +76,7 @@ By default, the containing div has this class: `datagrid datagrid-{$control->get
 By default, table has this class: `table table-hover table-striped table-bordered table-sm`. You can change that in `{block #table-class}`:
 
 ```
-{block table-class}table table-hovertable-condensed table-bordered
+{block table-class}table table-hovertable-condensed table-bordered{/block}
 ```
 
 ## Icons definition

--- a/.docs/template.md
+++ b/.docs/template.md
@@ -61,9 +61,19 @@ Or you can define column header template:
 
 ```
 
+
+## Containing div class definition
+
+By default, the containing div has this class: `datagrid datagrid-{$control->getFullName()}`. You can change that in `{block #datagrid-class}`:
+
+```
+{block datagrid-class}datagrid datagrid-{$control->getFullName()} custom-class{/block}
+```
+
+
 ## Table class definition
 
-By default, table has this class: `table table-hover table-striped table-bordered`. You can change that in `{block #table-class}`:
+By default, table has this class: `table table-hover table-striped table-bordered table-sm`. You can change that in `{block #table-class}`:
 
 ```
 {block table-class}table table-hovertable-condensed table-bordered

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -14,7 +14,7 @@
  * @param InlineEdit|null $inlineAdd   Inline add data
  *}
 
-<div class="datagrid datagrid-{$control->getFullName()}" data-refresh-state="{link refreshState!}">
+<div class="{block datagrid-class}datagrid datagrid-{$control->getFullName()}{/block}" data-refresh-state="{link refreshState!}">
 	<div n:snippet="grid">
 	{snippetArea gridSnippets}
 		{form filter, class => 'ajax'}


### PR DESCRIPTION
It would be nice to be able to add a custom html class to the containing div of the whole grid. In our use case, we would use that to add a html class to properly display a spinner when an user clicks the `Filter` button or uses the drag&drop sorting of the rows.


