### PR TITLE
V5.x - merge v5.7.3 and fix array_key_exists in getPerPage method

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2783,8 +2783,7 @@ class DataGrid extends Nette\Application\UI\Control
 
 		$per_page = $this->per_page ?: reset($items_per_page_list);
 
-		if (($per_page !== 'all' && !in_array((int) $this->per_page, $items_per_page_list, true))
-			|| ($per_page === 'all' && !array_key_exists($this->per_page, $items_per_page_list, true))) {
+		if (false === array_key_exists($this->per_page, $items_per_page_list)) {
 			$per_page = reset($items_per_page_list);
 		}
 


### PR DESCRIPTION
Merge v5.7.3 into 5.x branch and fix array_key_exists - this function has only 2 parameters, not 3.