### PR TITLE
The reset column filter functionality is broken when the datagrid is nested inside another component

### DIFF
--- a/assets/src/datagrid.coffee
+++ b/assets/src/datagrid.coffee
@@ -722,16 +722,4 @@ $.nette.ext('datagrid.reset-filter-by-column', {
 		if payload.non_empty_filters && payload.non_empty_filters.length
 			for key in payload.non_empty_filters
 				grid.find('[data-datagrid-reset-filter-by-column='+key+']').removeClass('hidden')
-
-			# Refresh their url (table header is not refreshed using snippets)
-			#
-			href = grid.find('.reset-filter').attr('href')
-
-			grid.find('[data-datagrid-reset-filter-by-column]').each ->
-				key = $(this).attr('data-datagrid-reset-filter-by-column')
-
-				new_href = href.replace('do=' + payload._datagrid_name + '-resetFilter', 'do=' + payload._datagrid_name + '-resetColumnFilter')
-				new_href += '&' + payload._datagrid_name + '-key=' + key
-
-				$(this).attr('href', new_href)
 })

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -541,7 +541,6 @@ class DataGrid extends Nette\Application\UI\Control
 		$template->filter_active = $this->isFilterActive();
 		$template->original_template = $this->getOriginalTemplateFile();
 		$template->icon_prefix = static::$icon_prefix;
-		$template->icon_prefix = static::$icon_prefix;
 		$template->items_detail = $this->items_detail;
 		$template->columns_visibility = $this->getColumnsVisibility();
 		$template->columnsSummary = $this->columnsSummary;
@@ -2520,6 +2519,7 @@ class DataGrid extends Nette\Application\UI\Control
 	{
 		if ($this->getPresenter()->isAjax()) {
 			$this->redrawControl('tbody');
+			$this->redrawControl('thead');
 			$this->redrawControl('pagination');
 			$this->redrawControl('summary');
 			$this->redrawControl('thead-group-action');

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -73,7 +73,7 @@
 				{/block}
 			{/if}
 			<table class="{block table-class}table table-hover table-striped table-bordered table-sm{/block}" n:snippet="table" n:block="data">
-				<thead n:block="header">
+				<thead n:block="header" n:snippet="thead">
 					<tr class="row-group-actions" n:if="$hasGroupActions || $exports || $toolbar_buttons || $control->canHideColumns() || $inlineAdd" n:block="group-actions">
 						<th colspan="{$control->getColumnsCount()}" class="ublaboo-datagrid-th-form-inline">
 							{if $hasGroupActions}


### PR DESCRIPTION
The reset column filter functionality is broken, when the datagrid component is nested inside another component.

Just to be clear, it is the X link in the table heading (screen included)

![reset_column](https://user-images.githubusercontent.com/13538235/69727172-47d62c00-1122-11ea-9fac-cd107bdbcba0.png)



So, the proposed solution is as follows.
I've removed the JS code, that changes the URL of the link to delete the filter on a column. The comment said that the code is there because table header is not refreshed using snippets. So, I've added the snippet to the `thead` element. Next, the snippet is invalidated in the `\Ublaboo\DataGrid\DataGrid::reload()` method.

Basically, I wonder why it was originally done that way and not via the snippet invalidation.

I've tested that change for grid, which is directly attached to the presenter as well as grid inside another component and it seems to be working just fine. i don't think this could cause any issue other than slightly bigger network traffic.