### PR TITLE
Fix sort callback condition

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -833,7 +833,7 @@ class DataGrid extends Control
 			$sort[$column->getSortingColumn()] = $order;
 		}
 
-		if ($sortCallback !== null && isset($column)) {
+		if ($sortCallback === null && isset($column)) {
 			$sortCallback = $column->getSortableCallback();
 		}
 


### PR DESCRIPTION
After fec69ac3aa298fa86c03b0b86af93a466340ab11 `!$sort_callback` has been incorrectly changed to `$sortCallback !== null`