### PR TITLE
Fix context in naja and $.nette adapters

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -51,11 +51,19 @@ if (typeof naja !== "undefined") {
 			.catch(params.error);
 	};
 
-	dataGridLoad = naja.load;
+	dataGridLoad = function () {
+		naja.load();
+	};
 } else if ($.nette) {
-	dataGridRegisterExtension = $.nette.ext;
-	dataGridRegisterAjaxCall = $.nette.ajax;
-	dataGridLoad = $.nette.load;
+	dataGridRegisterExtension = function (name, extension) {
+		$.nette.ext(name, extension);
+	};
+	dataGridRegisterAjaxCall = function (params) {
+		$.nette.ajax(params);
+	};
+	dataGridLoad = function () {
+		$.nette.load();
+	};
 } else {
 	throw new Error("Include Naja.js or nette.ajax for datagrids to work!")
 }


### PR DESCRIPTION
Because these functions are defined in global scope their "this" value is window. When we assign another function to this variables, their context is not changed. If any function uses ($.nette.ajax does) "this" it will not work because "this" will be "Window" instead of expected object.