### PR TITLE
Fix items detail form parameter in detail template

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -319,8 +319,8 @@
 									{if isset($toggle_detail) && $toggle_detail == $row->getId()}
 										{var $item_detail_params = ['item' => $item, '_form' => $filter] + $itemsDetail->getTemplateVariables()}
 
-										{if isset($filter['itemsDetail_form'])}
-											{var $item_detail_params['itemsDetail_form'] = $filter['itemsDetail_form']}
+										{if isset($filter['items_detail_form'])}
+											{var $item_detail_params['items_detail_form'] = $filter['items_detail_form']}
 										{/if}
 
 										{ifset #detail}


### PR DESCRIPTION
Item detail form parametr is not available after update to current version of datagrid.

In `Datagrid.php` item detail form is set as `items_detail_form ` and not `itemsDetail_form `.
```
		if ($itemsDetailForm instanceof Container) {
			$form['items_detail_form'] = $itemsDetailForm;
		}
```