### PR TITLE
DibiFluentPostgreDataSource - fix for BC break in dibi 4.1.2 in text search

### DIFF
--- a/src/DataSource/DibiFluentPostgreDataSource.php
+++ b/src/DataSource/DibiFluentPostgreDataSource.php
@@ -28,8 +28,7 @@ class DibiFluentPostgreDataSource extends DibiFluentDataSource
 			$words = $filter->hasSplitWordsSearch() === false ? [$value] : explode(' ', $value);
 
 			foreach ($words as $word) {
-				$escaped = $driver->escapeLike($word, 0);
-				$or[] = "$column ILIKE $escaped";
+				$or[] = "$column ILIKE " . $driver->escapeText('%' . $word . '%');
 			}
 		}
 


### PR DESCRIPTION
In Datagrid with DibiFluentPostgreDataSource text filters don't work with recent version of Dibi.

Reason is Dibi 4.1.2, where [dibi PR#346](https://github.com/dg/dibi/commit/294787a26e8bafdb6622d17300dbb8194b552304) changes meaning of function escapeLike parameter pos (0 => bitmask).

This PR simply changes escaping to not-use this function like others DibiFluent*DataSources do. So the code works with any version of Dibi (pre or post 4.1.2).