### PR TITLE
Fix group action button stays invisible (2nd try)

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -75,11 +75,11 @@
 									{='ublaboo_datagrid.group_actions'|translate}:
 									{foreach $filter['group_action']->getControls() as $form_control}
 										{if $form_control instanceof \Nette\Forms\Controls\SubmitButton}
-											{input $form_control, class => 'btn btn-primary btn-sm', style => 'display:none'}
+											{input $form_control, class => 'btn btn-primary btn-sm', hidden => TRUE}
 										{elseif $form_control->getName() == 'group_action'}
 											{input $form_control, class => 'form-control input-sm form-control-sm', disabled => TRUE}
 										{else}
-											{input $form_control, style => 'display:none'}
+											{input $form_control, hidden => TRUE}
 										{/if}
 									{/foreach}
 									{if $control->shouldShowSelectedRowsCount()}


### PR DESCRIPTION
CZ: Oprava chyby, kdy se nikdy nezobrazí tlačítko "Provést" u hromadných akcí (po kliknutí na nějakou položku ve výběru akce).

Kombinace datagrid.latte a (Nette 3.0) netteForms.js. Na počátku má tlačítko Provést v šabloně nastaveno display:none s tím, že se později zobrazí. Jenže netteForms.js (funkce Nette.toggle) to dříve dělalo pomocí smazání/nastavení atributu display, ale nově to dělá pomocí property hidden (commit), takže se nikdy nezobrazí.
