### PR TITLE
Dont send request when confirm cancel clicked for naja.js

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -6,6 +6,7 @@ if (typeof naja !== "undefined") {
 		var success = extension.success;
 		var before = extension.before;
 		var complete = extension.complete;
+		var interaction = extension.interaction;
 
 
 		var NewExtension = function NewExtension(naja, name) {
@@ -26,6 +27,11 @@ if (typeof naja !== "undefined") {
 			naja.addEventListener('interaction', function (params) {
 				params.options.nette = {
 					el: $(params.element)
+				}
+				if (interaction) {
+					if (!interaction(params.options)){
+						params.preventDefault();
+					}
 				}
 			});
 
@@ -93,18 +99,34 @@ $(document).on('click', '[data-datagrid-confirm]:not(.ajax)', function(e) {
 	}
 });
 
-dataGridRegisterExtension('datagrid.confirm', {
-	before: function(xhr, settings) {
-		var confirm_message;
-		if (settings.nette) {
-			confirm_message = settings.nette.el.data('datagrid-confirm');
-			if (confirm_message) {
-				return confirm(confirm_message);
+if (typeof naja !== "undefined") {
+	dataGridRegisterExtension('datagrid.confirm', {
+		before: function(xhr, settings) {
+			var confirm_message;
+			if (settings.nette) {
+				confirm_message = settings.nette.el.data('datagrid-confirm');
+				if (confirm_message) {
+					return confirm(confirm_message);
+				}
 			}
+			return true;
 		}
-		return true;
-	}
-});
+	});
+} else {
+	dataGridRegisterExtension('datagrid.confirm', {
+		interaction: function(settings) {
+			var confirm_message;
+			if (settings.nette) {
+				confirm_message = settings.nette.el.data('datagrid-confirm');
+				if (confirm_message) {
+					return confirm(confirm_message);
+				}
+			}
+			return true;
+		}
+	});
+}
+
 
 $(document).on('change', 'select[data-autosubmit-per-page]', function() {
 	var button;

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -101,7 +101,7 @@ $(document).on('click', '[data-datagrid-confirm]:not(.ajax)', function(e) {
 
 if (typeof naja !== "undefined") {
 	dataGridRegisterExtension('datagrid.confirm', {
-		before: function(xhr, settings) {
+		interaction: function(settings) {
 			var confirm_message;
 			if (settings.nette) {
 				confirm_message = settings.nette.el.data('datagrid-confirm');
@@ -114,7 +114,7 @@ if (typeof naja !== "undefined") {
 	});
 } else {
 	dataGridRegisterExtension('datagrid.confirm', {
-		interaction: function(settings) {
+		before: function(xhr, settings) {
 			var confirm_message;
 			if (settings.nette) {
 				confirm_message = settings.nette.el.data('datagrid-confirm');


### PR DESCRIPTION
When you click Cancel in confirm message window, request was sent anyway. This is a problem especially for delete signals.

In Naja.js you have to call interaction event instead of before to stop request.
Doc: https://naja.js.org/#/extensions-custom
