### PR TITLE
Hotfix/phpstan unnecessary ignore and onsubmit nette form usage

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,3 @@ includes:
 parameters:
 	ignoreErrors:
 		- '#^Access to an undefined property Nette\\Bridges\\ApplicationLatte\\Template::\$.+\.$#'
-		- '#^Array \(array<callable\(Nette\\Forms\\Form\): void>\) does not accept array\(\$this\(.+\), .+\)\.$#'

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -17,6 +17,7 @@ use Nette\Bridges\ApplicationLatte\Template;
 use Nette\ComponentModel\IContainer;
 use Nette\Forms\Container;
 use Nette\Forms\Controls\SubmitButton as FormsSubmitButton;
+use Nette\Forms\Form as NetteForm;
 use Nette\Forms\IControl;
 use Nette\Http\SessionSection;
 use Nette\Localization\ITranslator;
@@ -1496,7 +1497,9 @@ class DataGrid extends Control
 		$form->addSubmit('perPage_submit', 'ublaboo_datagrid.per_page_submit')
 			->setValidationScope([$select]);
 
-		$form->onSubmit[] = [$this, 'filterSucceeded'];
+		$form->onSubmit[] = function (NetteForm $form): void {
+			$this->filterSucceeded($form);
+		};
 
 		return $form;
 	}
@@ -1548,7 +1551,7 @@ class DataGrid extends Control
 	/**
 	 * Set $this->filter values after filter form submitted
 	 */
-	public function filterSucceeded(Form $form): void
+	public function filterSucceeded(NetteForm $form): void
 	{
 		if ($this->snippetsSet) {
 			return;

--- a/src/GroupAction/GroupActionCollection.php
+++ b/src/GroupAction/GroupActionCollection.php
@@ -7,6 +7,7 @@ namespace Ublaboo\DataGrid\GroupAction;
 use Nette;
 use Nette\Application\UI\Form;
 use Nette\Forms\Container;
+use Nette\Forms\Form as NetteForm;
 use Ublaboo\DataGrid\DataGrid;
 use Ublaboo\DataGrid\Exception\DataGridGroupActionException;
 use UnexpectedValueException;
@@ -121,14 +122,16 @@ class GroupActionCollection
 				strtolower($this->datagrid->getFullName()) . 'group_action_submit'
 			);
 
-		$form->onSubmit[] = [$this, 'submitted'];
+		$form->onSubmit[] = function (NetteForm $form): void {
+			$this->submitted($form);
+		};
 	}
 
 
 	/**
 	 * Pass "sub"-form submission forward to custom submit function
 	 */
-	public function submitted(Form $form): void
+	public function submitted(NetteForm $form): void
 	{
 		if (!isset($form['group_action']['submit']) || !$form['group_action']['submit']->isSubmittedBy()) {
 			return;


### PR DESCRIPTION
Remove unnecessary phpstan ignoreErrors config and fix code.
*edit - remove unnecessary phpstan ignoreErrors config
*fix - confusion between Nette\Application\UI\Form and Nette\Forms\Form - onSubmit is expecting Nette\Forms\Form
*fix - onSubmit definition with callback - phpstan error fix
