### PR TITLE
assets: replace pushState to replaceState in history API

### DIFF
--- a/assets/datagrid-instant-url-refresh.js
+++ b/assets/datagrid-instant-url-refresh.js
@@ -5,7 +5,9 @@ if (typeof naja !== "undefined") {
 		var method = params.type || 'GET';
 		var data = params.data || null;
 
-		naja.makeRequest(method, params.url, data, {})
+		naja.makeRequest(method, params.url, data, {
+			history: 'replace'
+		})
 			.then(params.success)
 			.catch(params.error);
 	};

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -522,7 +522,7 @@ dataGridRegisterExtension('datagrid.url', {
 	success: function(payload) {
 		var host, path, query, url;
 		if (payload._datagrid_url) {
-			if (window.history.pushState) {
+			if (window.history.replaceState) {
 				host = window.location.protocol + "//" + window.location.host;
 				path = window.location.pathname;
 				query = window.datagridSerializeUrl(payload.state).replace(/&+$/gm, '');
@@ -533,7 +533,7 @@ dataGridRegisterExtension('datagrid.url', {
 				}
 				url += window.location.hash;
 				if (window.location.href !== url) {
-					return window.history.pushState({
+					return window.history.replaceState({
 						path: url
 					}, '', url);
 				}


### PR DESCRIPTION
This should fix browsers BACK button funcionality, when in some cases (like filtering), you must hit back button 3 times to go back...

Not sure, if it is necessary for nette.ajax.js too in assets/datagrid-instant-url-refresh.js