### PR TITLE
Fix - paginator option 'All' does not work

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2784,7 +2784,7 @@ class DataGrid extends Nette\Application\UI\Control
 		$per_page = $this->per_page ?: reset($items_per_page_list);
 
 		if (($per_page !== 'all' && !in_array((int) $this->per_page, $items_per_page_list, true))
-			|| ($per_page === 'all' && !array_key_exists($this->per_page, $items_per_page_list))) {
+			|| ($per_page === 'all' && !in_array($this->per_page, $items_per_page_list))) {
 			$per_page = reset($items_per_page_list);
 		}
 


### PR DESCRIPTION
Problem is with array_key_exists(). There must be in_array().

Variable $items_per_page_list looks like this:
0 => 10
1 => 20
2 => 50
3 => "all"
Even if it is then translated into e.g Czech.