### PR TITLE
Button group actions

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -254,25 +254,39 @@ datagridShiftGroupSelection = function() {
 datagridShiftGroupSelection();
 
 document.addEventListener('change', function(e) {
-	var checked_inputs, counter, event, grid, i, ie, input, inputs, len, results, select, total;
+	var buttons, checked_inputs, counter, event, grid, i, ie, input, inputs, len, results, select, total;
 	grid = e.target.getAttribute('data-check');
 	if (grid) {
 		checked_inputs = document.querySelectorAll('input[data-check-all-' + grid + ']:checked');
 		select = document.querySelector('.datagrid-' + grid + ' select[name="group_action[group_action]"]');
-		if (select) {
-			counter = document.querySelector('.datagrid-' + grid + ' .datagrid-selected-rows-count');
-			if (checked_inputs.length) {
+		buttons = document.querySelectorAll('.datagrid-' + grid + ' input[type="submit"]');
+		counter = document.querySelector('.datagrid-' + grid + ' .datagrid-selected-rows-count');
+
+		if (checked_inputs.length) {
+			if (buttons) {
+				buttons.forEach(function (button) {
+					button.disabled = false;
+				});
+			}
+			if (select) {
 				select.disabled = false;
-				total = document.querySelectorAll('input[data-check-all-' + grid + ']').length;
-				if (counter) {
-					counter.innerHTML = checked_inputs.length + '/' + total;
-				}
-			} else {
+			}
+			total = document.querySelectorAll('input[data-check-all-' + grid + ']').length;
+			if (counter) {
+				counter.innerHTML = checked_inputs.length + '/' + total;
+			}
+		} else {
+			if (buttons) {
+				buttons.forEach(function (button) {
+					button.disabled = true;
+				});
+			}
+			if (select) {
 				select.disabled = true;
 				select.value = "";
-				if (counter) {
-					counter.innerHTML = "";
-				}
+			}
+			if (counter) {
+				counter.innerHTML = "";
 			}
 		}
 		ie = window.navigator.userAgent.indexOf("MSIE ");

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1983,6 +1983,12 @@ class DataGrid extends Control
 	}
 
 
+	public function addGroupButtonAction(string $title, ?string $class = null): GroupAction
+	{
+		return $this->getGroupActionCollection()->addGroupButtonAction($title, $class);
+	}
+
+
 	public function addGroupSelectAction(string $title, array $options = []): GroupAction
 	{
 		return $this->getGroupActionCollection()->addGroupSelectAction($title, $options);

--- a/src/GroupAction/GroupButtonAction.php
+++ b/src/GroupAction/GroupButtonAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\GroupAction;
+
+class GroupButtonAction extends GroupAction
+{
+
+	/**
+	 * @var array|callable[]
+	 */
+	public $onClick = [];
+
+	/**
+	 * @var string
+	 */
+	protected $class = 'btn btn-sm btn-success';
+
+
+	public function __construct(string $title, ?string $class = null)
+	{
+		parent::__construct($title);
+
+		if (!is_null($class) && !empty($class)) {
+			$this->class = $class;
+		}
+	}
+
+}

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -72,10 +72,14 @@
 						<th colspan="{$control->getColumnsCount()}" class="ublaboo-datagrid-th-form-inline">
 							{if $hasGroupActions}
 								{block group_actions}
-									{='ublaboo_datagrid.group_actions'|translate}:
+									<span class="datagrid-group-action-title">
+										{='ublaboo_datagrid.group_actions'|translate}:
+									</span>
 									{foreach $filter['group_action']->getControls() as $form_control}
-										{if $form_control instanceof \Nette\Forms\Controls\SubmitButton}
-											{input $form_control, class => 'btn btn-primary btn-sm'}
+										{if $form_control instanceof \Nette\Forms\Controls\SubmitButton && $form_control->getName() === 'submit'}
+											{input $form_control, class => 'btn btn-primary btn-sm', disabled => TRUE}
+										{elseif $form_control instanceof \Nette\Forms\Controls\SubmitButton}
+											{input $form_control, disabled => TRUE}
 										{elseif $form_control->getName() == 'group_action'}
 											{input $form_control, class => 'form-control input-sm form-control-sm', disabled => TRUE}
 										{else}


### PR DESCRIPTION
Added ability to add groupAction directly as a button

```php
   $grid->addGroupButton('Export PDF')->onClick[] = [$this, 'testAction'];
```

Added also "disabling" group action submit button when no group action is actualy selected.