### PR TITLE
Added check if filter range value is numeric for DoctrineDataSource

### DIFF
--- a/src/DataSource/DoctrineCollectionDataSource.php
+++ b/src/DataSource/DoctrineCollectionDataSource.php
@@ -178,18 +178,16 @@ final class DoctrineCollectionDataSource extends FilterableDataSource implements
 	protected function applyFilterRange(FilterRange $filter): void
 	{
 		$conditions = $filter->getCondition();
-		$values = $conditions[$filter->getColumn()];
 
-		$valueFrom = $values['from'];
+		$valueFrom = $conditions[$filter->getColumn()]['from'];
+		$valueTo = $conditions[$filter->getColumn()]['to'];
 
-		if ((bool) $valueFrom) {
+		if (is_numeric($valueFrom)) {
 			$expr = Criteria::expr()->gte($filter->getColumn(), $valueFrom);
 			$this->criteria->andWhere($expr);
 		}
 
-		$valueTo = $values['to'];
-
-		if ((bool) $valueTo) {
+		if (is_numeric($valueTo)) {
 			$expr = Criteria::expr()->lte($filter->getColumn(), $valueTo);
 			$this->criteria->andWhere($expr);
 		}

--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -254,12 +254,12 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource, IA
 		$valueFrom = $conditions[$filter->getColumn()]['from'];
 		$valueTo = $conditions[$filter->getColumn()]['to'];
 
-		if ($valueFrom) {
+		if (is_numeric($valueFrom)) {
 			$p = $this->getPlaceholder();
 			$this->dataSource->andWhere("$c >= :$p")->setParameter($p, $valueFrom);
 		}
 
-		if ($valueTo) {
+		if (is_numeric($valueTo)) {
 			$p = $this->getPlaceholder();
 			$this->dataSource->andWhere("$c <= :$p")->setParameter($p, $valueTo);
 		}


### PR DESCRIPTION
Range filter is inherently for integer values, however when you try to fill in text instead, it will throw exception.