### PR TITLE
Add naja 2.0 support

### DIFF
--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -1,6 +1,7 @@
 var dataGridRegisterExtension;
 
 if (typeof naja !== "undefined") {
+	var isNaja2 = function () { return naja.version >= 2 };
 	dataGridRegisterExtension = function (name, extension) {
 		var init = extension.init;
 		var success = extension.success;
@@ -9,44 +10,43 @@ if (typeof naja !== "undefined") {
 
 
 		var NewExtension = function NewExtension(naja, name) {
-			this.naja = naja;
 			this.name = name;
 			var extension = this;
 
 			extension.initialize = function (naja) {
-				extension.naja = naja;
-			}
+				if(init) {
+					naja.addEventListener('init', function (params)  {
+						init(params.defaultOptions);
+					});
+				}
 
-			if(init) {
-				extension.naja.addEventListener('init', function (params)  {
-					init(params.defaultOptions);
-				});
-			}
+				if(success) {
+					naja.addEventListener('success', function (params)  {
+						var payload = isNaja2() ? params.payload : params.response;
+						success(payload, params.options);
+					});
+				}
 
-			if(success) {
-				extension.naja.addEventListener('success', function (params)  {
-					var payload = naja.version >=2 ? params.payload : params.response;
-					success(payload, params.options);
-				});
-			}
+				if(before) {
+					naja.addEventListener('before', function (params) {
+						before(params.xhr || params.request, params.options);
+					});
+				}
 
-			if(before) {
-				extension.naja.addEventListener('before', function (params) {
-					before(params.xhr || params.request, params.options);
-				});
+				if(complete) {
+					naja.addEventListener('complete', function (params) {
+						complete(params.xhr || params.request, params.options);
+					});
+				}
 			}
-
-			if(complete) {
-				extension.naja.addEventListener('complete', function (params) {
-					complete(params.xhr || params.request, params.options);
-				});
+			if (!naja.version || !isNaja2()) {
+				extension.initialize(naja);
 			}
-
 			return extension;
 		}
 
-		if (naja.VERSION >=2) {
-			naja.registerExtension(NewExtension(null, name));
+		if (isNaja2()) {
+			naja.registerExtension(new NewExtension(null, name));
 		} else {
 			naja.registerExtension(NewExtension, name);
 		}

--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -11,9 +11,8 @@ if (typeof naja !== "undefined") {
 
 		var NewExtension = function NewExtension(naja, name) {
 			this.name = name;
-			var extension = this;
 
-			extension.initialize = function (naja) {
+			this.initialize = function (naja) {
 				if(init) {
 					naja.addEventListener('init', function (params)  {
 						init(params.defaultOptions);
@@ -42,7 +41,7 @@ if (typeof naja !== "undefined") {
 			if (!naja.version || !isNaja2()) {
 				extension.initialize(naja);
 			}
-			return extension;
+			return this;
 		}
 
 		if (isNaja2()) {

--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -39,7 +39,7 @@ if (typeof naja !== "undefined") {
 				}
 			}
 			if (!naja.version || !isNaja2()) {
-				extension.initialize(naja);
+				this.initialize(naja);
 			}
 			return this;
 		}

--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -2,6 +2,8 @@ var dataGridRegisterExtension;
 
 if (typeof naja !== "undefined") {
 	var isNaja2 = function () { return naja && naja.VERSION && naja.VERSION >= 2 };
+	var najaEventParams = function (params) { return isNaja2() ? params.detail : params };
+	var najaRequest = function (params) { return isNaja2() ? params.detail.request : params.xhr };
 	dataGridRegisterExtension = function (name, extension) {
 		var init = extension.init;
 		var success = extension.success;
@@ -15,26 +17,26 @@ if (typeof naja !== "undefined") {
 			this.initialize = function (naja) {
 				if(init) {
 					naja.addEventListener('init', function (params)  {
-						init(params.defaultOptions);
+						init(najaEventParams(params).defaultOptions);
 					});
 				}
 
 				if(success) {
 					naja.addEventListener('success', function (params)  {
-						var payload = isNaja2() ? params.payload : params.response;
-						success(payload, params.options);
+						var payload = isNaja2() ? params.detail.payload : params.response;
+						success(payload, najaEventParams(params).options);
 					});
 				}
 
 				if(before) {
 					naja.addEventListener('before', function (params) {
-						before(params.xhr || params.request, params.options);
+						before(najaRequest(params), najaEventParams(params).options);
 					});
 				}
 
 				if(complete) {
 					naja.addEventListener('complete', function (params) {
-						complete(params.xhr || params.request, params.options);
+						complete(najaRequest(params), najaEventParams(params).options);
 					});
 				}
 			}

--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -1,7 +1,7 @@
 var dataGridRegisterExtension;
 
 if (typeof naja !== "undefined") {
-	var isNaja2 = function () { return naja.version >= 2 };
+	var isNaja2 = function () { return naja && naja.VERSION && naja.VERSION >= 2 };
 	dataGridRegisterExtension = function (name, extension) {
 		var init = extension.init;
 		var success = extension.success;
@@ -38,7 +38,7 @@ if (typeof naja !== "undefined") {
 					});
 				}
 			}
-			if (!naja.version || !isNaja2()) {
+			if (!isNaja2()) {
 				this.initialize(naja);
 			}
 			return this;

--- a/assets/datagrid-spinners.js
+++ b/assets/datagrid-spinners.js
@@ -9,36 +9,47 @@ if (typeof naja !== "undefined") {
 
 
 		var NewExtension = function NewExtension(naja, name) {
+			this.naja = naja;
 			this.name = name;
+			var extension = this;
+
+			extension.initialize = function (naja) {
+				extension.naja = naja;
+			}
 
 			if(init) {
-				naja.addEventListener('init', function (params)  {
+				extension.naja.addEventListener('init', function (params)  {
 					init(params.defaultOptions);
 				});
 			}
 
 			if(success) {
-				naja.addEventListener('success', function (params)  {
-					success(params.response, params.options);
+				extension.naja.addEventListener('success', function (params)  {
+					var payload = naja.version >=2 ? params.payload : params.response;
+					success(payload, params.options);
 				});
 			}
 
 			if(before) {
-				naja.addEventListener('before', function (params) {
-					before(params.xhr, params.options);
+				extension.naja.addEventListener('before', function (params) {
+					before(params.xhr || params.request, params.options);
 				});
 			}
 
 			if(complete) {
-				naja.addEventListener('complete', function (params) {
-					complete(params.xhr, params.options);
+				extension.naja.addEventListener('complete', function (params) {
+					complete(params.xhr || params.request, params.options);
 				});
 			}
-		
-			return this;
+
+			return extension;
 		}
 
-		naja.registerExtension(NewExtension, name);
+		if (naja.VERSION >=2) {
+			naja.registerExtension(NewExtension(null, name));
+		} else {
+			naja.registerExtension(NewExtension, name);
+		}
 	};
 } else if ($.nette) {
 		dataGridRegisterExtension = function (name, extension) {

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -1,7 +1,7 @@
 var dataGridRegisterExtension, dataGridRegisterAjaxCall, dataGridLoad, dataGridSubmitForm;
 
 if (typeof naja !== "undefined") {
-	var isNaja2 = function () { return naja.version >= 2 };
+	var isNaja2 = function () { return naja && naja.VERSION && naja.VERSION >= 2 };
 	dataGridRegisterExtension = function (name, extension) {
 		var init = extension.init;
 		var success = extension.success;
@@ -56,7 +56,7 @@ if (typeof naja !== "undefined") {
 					});
 				}
 			}
-			if (!naja.version || !isNaja2()) {
+			if (!isNaja2()) {
 				this.initialize(naja);
 			}
 			return this;

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -12,9 +12,8 @@ if (typeof naja !== "undefined") {
 
 		var NewExtension = function NewExtension(naja, name) {
 			this.name = name;
-			var extension = this;
 
-			extension.initialize = function (naja) {
+			this.initialize = function (naja) {
 				if(init) {
 					naja.addEventListener('init', function (params)  {
 						init(params.defaultOptions);
@@ -58,9 +57,9 @@ if (typeof naja !== "undefined") {
 				}
 			}
 			if (!naja.version || !isNaja2()) {
-				extension.initialize(naja);
+				this.initialize(naja);
 			}
-			return extension;
+			return this;
 		}
 
 		if (isNaja2()) {

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -24,7 +24,7 @@ if (typeof naja !== "undefined") {
 
 				if(success) {
 					naja.addEventListener('success', function (params)  {
-						var payload = isNaja2() ? params.detail.payload : najaEventParams(params).response;
+						var payload = isNaja2() ? params.detail.payload : params.response;
 						success(payload, najaEventParams(params).options);
 					});
 				}


### PR DESCRIPTION
This PR adds `naja:2.0` support to `datagrid` assets while maintaining full backwards compatibility with `naja:1.x` versions.

Followed [Upgrading from 1.x guide](https://naja.js.org/#/upgrade-from-1).

**Changes:**

- added `naja` version check
- added `najaEventParams` helper to extract `naja` event properties
- added `najaRequest` helper to extract `request` or `xhr` from `naja` event based on version
- updated `NewExtension` classes to work with both `1.x || 2.x` versions