### PR TITLE
Fix ExportCsv blank output

### DIFF
--- a/src/Export/ExportCsv.php
+++ b/src/Export/ExportCsv.php
@@ -46,7 +46,11 @@ class ExportCsv extends Export
 			array $data,
 			DataGrid $grid
 		) use ($name, $outputEncoding, $delimiter, $includeBom): void {
-			$columns = $this->getColumns() ?? $this->grid->getColumns();
+			$columns = $this->getColumns();
+			
+			if ($columns === []) {
+				$columns = $this->grid->getColumns();
+			}
 
 			$csvDataModel = new CsvDataModel($data, $columns, $this->grid->getTranslator());
 


### PR DESCRIPTION
Regression from a56c9d3563, which results in rows with no columns (since `getColumns` never returns `null`).