### PR TITLE
Fix type error in str_replace in PHP 8.0

### DIFF
--- a/src/Column/Action.php
+++ b/src/Column/Action.php
@@ -281,7 +281,7 @@ class Action extends Column
 
 			return str_replace(
 				'%s',
-				(string)$row->getValue($this->confirmation->getPlaceholderName()),
+				(string) $row->getValue($this->confirmation->getPlaceholderName()),
 				$question
 			);
 		}

--- a/src/Column/Action.php
+++ b/src/Column/Action.php
@@ -281,7 +281,7 @@ class Action extends Column
 
 			return str_replace(
 				'%s',
-				$row->getValue($this->confirmation->getPlaceholderName()),
+				(string)$row->getValue($this->confirmation->getPlaceholderName()),
 				$question
 			);
 		}


### PR DESCRIPTION
In PHP 8.0 in some situation is fired TypeError: Argument 2 ($replace) must be of type array|string, int given

$grid->addAction('name', 'title', 'href')
 ->setConfirmation(
  new StringConfirmation('Delete number: %s?', 'number')
 );

Where "number" is defined as integer in database.