### PR TITLE
Convert primaryKey value to int if it is numeric

### DIFF
--- a/src/DataSource/DoctrineCollectionDataSource.php
+++ b/src/DataSource/DoctrineCollectionDataSource.php
@@ -78,6 +78,10 @@ final class DoctrineCollectionDataSource extends FilterableDataSource implements
 	public function filterOne(array $condition): IDataSource
 	{
 		foreach ($condition as $column => $value) {
+			if ($column === $this->primaryKey && is_numeric($value)) {
+				$value = (int) $value;
+			}
+
 			$expr = Criteria::expr()->eq($column, $value);
 			$this->criteria->andWhere($expr);
 		}


### PR DESCRIPTION
I have issue with inline edit not working when using Doctrine Collection, I tracked issue to the type of the value when filtering for one row.

I don't know if I should leave it like this or treat the issue globally and cast all numerics to ints? What do you think?