### PR TITLE
Improved group action submit button selector

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -280,11 +280,10 @@ document.addEventListener('change', function(e) {
 	var buttons, checked_inputs, counter, event, grid, i, ie, input, inputs, len, results, select, total;
 	grid = e.target.getAttribute('data-check');
 	if (grid) {
-		var selector = '.datagrid-' + grid + ' .row-group-actions';
 		checked_inputs = document.querySelectorAll('input[data-check-all-' + grid + ']:checked');
-		select = document.querySelector(selector + ' select[name="group_action[group_action]"]');
-		buttons = document.querySelectorAll(selector + ' input[type="submit"], ' + selector + ' button[type="submit"]');
-		counter = document.querySelector(selector + ' .datagrid-selected-rows-count');
+		select = document.querySelector('.datagrid-' + grid + ' select[name="group_action[group_action]"]');
+		buttons = document.querySelectorAll('.datagrid-' + grid + ' .row-group-actions *[type="submit"]');
+		counter = document.querySelector('.datagrid-' + grid + ' .datagrid-selected-rows-count');
 
 		if (checked_inputs.length) {
 			if (buttons) {

--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -280,13 +280,11 @@ document.addEventListener('change', function(e) {
 	var buttons, checked_inputs, counter, event, grid, i, ie, input, inputs, len, results, select, total;
 	grid = e.target.getAttribute('data-check');
 	if (grid) {
+		var selector = '.datagrid-' + grid + ' .row-group-actions';
 		checked_inputs = document.querySelectorAll('input[data-check-all-' + grid + ']:checked');
-		select = document.querySelector('.datagrid-' + grid + ' select[name="group_action[group_action]"]');
-		buttons = document.querySelectorAll('.datagrid-' + grid + ' input[type="submit"]');
-		if (buttons.length === 0) {
-			buttons = document.querySelectorAll('.datagrid-' + grid + ' button[type="submit"]');
-		}
-		counter = document.querySelector('.datagrid-' + grid + ' .datagrid-selected-rows-count');
+		select = document.querySelector(selector + ' select[name="group_action[group_action]"]');
+		buttons = document.querySelectorAll(selector + ' input[type="submit"], ' + selector + ' button[type="submit"]');
+		counter = document.querySelector(selector + ' .datagrid-selected-rows-count');
 
 		if (checked_inputs.length) {
 			if (buttons) {


### PR DESCRIPTION
Hi,
I was getting group actions to work in my custom BS4 template, however I wanted the button to have a icon, so I used `<button>` which then did not work with button enabling.

This modification should support both buttons and inputs of type submit while also containing the disabling/enabling to just group actions.