### PR TITLE
Fix for twice translated label of FilterSelect

### DIFF
--- a/src/Filter/FilterSelect.php
+++ b/src/Filter/FilterSelect.php
@@ -67,17 +67,10 @@ class FilterSelect extends OneColumnFilter
 			throw new UnexpectedValueException();
 		}
 
-		if (!$this->translateOptions) {
-			$select = $this->addControl(
-				$container,
-				$this->key,
-				$translator->translate($this->name),
-				$this->options
-			);
+		$select = $this->addControl($container, $this->key, $this->name, $this->options);
 
+		if (!$this->translateOptions) {
 			$select->setTranslator(null);
-		} else {
-			$this->addControl($container, $this->key, $this->name, $this->options);
 		}
 	}
 


### PR DESCRIPTION
When using FilterSelect in multi-language app using translator I got twice translated label of this select filter.

Reason is that when option translateOptions of FilterSelect is set to false (default value), the translator is set to null (that is ok) and the caption is manually translated. This probably worked years ago, but now the caption is translated twice. 

What happens now (I guess since 2017 commit of [Nette Forms](https://github.com/nette/forms/commit/782b31991854df25ca3b36f4449f6bc8f0330fcd#diff-7c3dcaa0dd0a74892784a16caf1f8f2f3db011617f9b05cc3d691747398e32da)) is, that label always use translator of form, not the translator of the select component.

Solution is to remove the manual translation of caption.

