### PR TITLE
Fix PHPstan error

### DIFF
--- a/src/Utils/ItemDetailForm.php
+++ b/src/Utils/ItemDetailForm.php
@@ -20,7 +20,7 @@ final class ItemDetailForm extends Container
 	private $callableSetContainer;
 
 	/**
-	 * @var array
+	 * @var ?array
 	 */
 	private $httpPost;
 


### PR DESCRIPTION
```
vendor/bin/phpstan analyse -l max -c phpstan.neon --memory-limit=512M src
 95/95 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -----------------------------------------------------------------------------------------
  Line   Utils/ItemDetailForm.php
 ------ -----------------------------------------------------------------------------------------
  88     Property Ublaboo\DataGrid\Utils\ItemDetailForm::$httpPost (array) does not accept null.
 ------ -----------------------------------------------------------------------------------------
```