### PR TITLE
Fixed ignoring input content in filter

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1491,7 +1491,7 @@ class DataGrid extends Control
 			return;
 		}
 
-		$values = (array) $form->getValues();
+		$values = $form->getUnsafeValues('array');
 
 		if ($this->getPresenterInstance()->isAjax()) {
 			if (isset($form['group_action']['submit']) && $form['group_action']['submit']->isSubmittedBy()) {


### PR DESCRIPTION
With new Nette forms there is an error, which causes that values from filter are ignored.
This PR should provide fix.