### PR TITLE
Fix filter throws exception ($values are not array of ArrayAssoc)

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1491,7 +1491,7 @@ class DataGrid extends Control
 			return;
 		}
 
-		$values = $form->getUnsafeValues('array');
+		$values = (array) $form->getUnsafeValues(null);
 
 		if ($this->getPresenterInstance()->isAjax()) {
 			if (isset($form['group_action']['submit']) && $form['group_action']['submit']->isSubmittedBy()) {

--- a/tests/Cases/FilterTest.phpt
+++ b/tests/Cases/FilterTest.phpt
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ublaboo\DataGrid\Tests\Cases;
+
+require __DIR__ . '/../bootstrap.php';
+
+use Nette\Application\AbortException;
+use Tester\Assert;
+use Tester\TestCase;
+use Ublaboo\DataGrid\DataGrid;
+use Ublaboo\DataGrid\Tests\Files\TestingDataGridFactoryRouter;
+
+final class FilterTest extends TestCase
+{
+
+	public function testFilterSubmit(): void
+	{
+		$factory = new TestingDataGridFactoryRouter();
+		/** @var DataGrid $grid */
+		$grid = $factory->createTestingDataGrid()->getComponent('grid');
+		$filterForm = $grid->createComponentFilter();
+
+		Assert::exception(function() use ($grid, $filterForm): void {
+			$grid->filterSucceeded($filterForm);
+		}, AbortException::class);
+	}
+
+}
+
+(new FilterTest)->run();


### PR DESCRIPTION
Fix for fix #997 - $values should be array of ArrayHash.

DataGrid.php checks $values['filter'] to be ArrayHash or it throws exception.

$values before PR:
![obrazek](https://user-images.githubusercontent.com/24586123/144576307-edf156b6-030f-4599-9fd8-4631f2bb7bda.png)

$values after PR:
![obrazek](https://user-images.githubusercontent.com/24586123/144576111-32ca5a40-c67d-4f68-955a-eccc30afba08.png)

