### PR TITLE
add new snippet - toolbarButtons

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -93,9 +93,11 @@
 							{/if}
 
 							<div class="datagrid-toolbar" n:if="$control->canHideColumns() || $inlineAdd || $exports || $toolbarButtons">
+								{snippet toolbarButtons}
 								<span n:if="$toolbarButtons" n:snippet="toolbar">
 									{foreach $toolbarButtons as $toolbar_button}{$toolbar_button->renderButton()}{/foreach}
 								</span>
+								{/snippet}
 
 								<span class="datagrid-exports" n:if="$exports" n:snippet="exports" n:block="exports">
 									{foreach $exports as $export}{$export->render()}{/foreach}


### PR DESCRIPTION
With this new snippet is possible add reset button up of grid

Something like this
```
		$grid->onAnchor[] = function () use ($grid): void {
			$grid->addToolbarButton($grid->getName() . '-resetFilter!', 'reset filtru')
				->setRendererOnCondition(
					fn () => Html::el('span'),
					fn () => !$grid->isFilterActive()
				)
				->setClass('ajax btn btn-warning btn-sm reset-filter');
		};

		$grid->onFiltersAssembled[] = function () use ($grid): void {
			$grid->redrawControl('toolbarButtons');
		};
```