### PR TITLE
Fix for PHP 8.1 "Implicit conversion from float to int loses precision"

### DIFF
--- a/src/Traits/TButtonRenderer.php
+++ b/src/Traits/TButtonRenderer.php
@@ -97,8 +97,8 @@ trait TButtonRenderer
 	{
 		$value = $row->getValue($column);
 
-		if ((is_scalar($value) || $value === null) && isset($this->replacements[$value])) {
-			return [true, $this->replacements[$value]];
+		if ((is_scalar($value) || $value === null) && isset($this->replacements[gettype($value) == 'double' ? (int)$value : $value])) {
+			return [true, $this->replacements[gettype($value) == 'double' ? (int)$value : $value]];
 		}
 
 		return [false, null];

--- a/src/Traits/TButtonRenderer.php
+++ b/src/Traits/TButtonRenderer.php
@@ -97,8 +97,9 @@ trait TButtonRenderer
 	{
 		$value = $row->getValue($column);
 
-		if ((is_scalar($value) || $value === null) && isset($this->replacements[gettype($value) == 'double' ? (int)$value : $value])) {
-			return [true, $this->replacements[gettype($value) == 'double' ? (int)$value : $value]];
+		if ((is_scalar($value) || $value === null) &&
+			isset($this->replacements[gettype($value) === 'double' ? (int) $value : $value])) {
+			return [true, $this->replacements[gettype($value) === 'double' ? (int) $value : $value]];
 		}
 
 		return [false, null];


### PR DESCRIPTION
Float value in number column with PHP 8.1 throws deprecated error - "Implicit conversion from float 123.56 to int loses precision". 

This PR fixes this by explicit type casting floats to int (for use as array index).