### PR TITLE
GroupActionMultiselect fix

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -839,8 +839,8 @@ datagridGroupActionMultiSelect = function() {
 			$(this).removeAttr('id');
 			id = $(this).data('datagrid-multiselect-id');
 			$(this).on('loaded.bs.select', function(e) {
-				$(this).parent().attr('style', 'display:none;');
-				return $(this).parent().find('.hidden').removeClass('hidden').addClass('btn-default btn-secondary');
+				$(this).parent().attr('hidden', true);
+				return $(this).parent().find('.hidden').removeClass('hidden').addClass('btn-default btn-light');
 			});
 			return $(this).on('rendered.bs.select', function(e) {
 				return $(this).parent().attr('id', id);


### PR DESCRIPTION
I had an issue that multiselect for multiselect group action was permanently hidden, it works after this change.

I also changed multiselect button class to `btn-light` which is more similar to BS3 `btn-default` and standard select.