### PR TITLE
Update the filterMultiSelect initialization

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -112,7 +112,7 @@ if (typeof naja !== "undefined") {
 }
 
 
-var datagridFitlerMultiSelect, datagridGroupActionMultiSelect, datagridShiftGroupSelection, datagridSortable, datagridSortableTree, getEventDomPath,
+var datagridFilterMultiSelect, datagridGroupActionMultiSelect, datagridShiftGroupSelection, datagridSortable, datagridSortableTree, getEventDomPath,
 	indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 $(document).on('click', '[data-datagrid-confirm]:not(.ajax)', function(e) {
@@ -808,20 +808,30 @@ dataGridRegisterExtension('datagrid-toggle-inline-add', {
 	}
 });
 
-datagridFitlerMultiSelect = function() {
+datagridFilterMultiSelect = function() {
 	var select = $('.selectpicker').first();
 
 	if ($.fn.selectpicker) {
-		return $.fn.selectpicker.defaults = {
+		let defaults = $.fn.selectpicker.defaults = {
 			countSelectedText: select.data('i18n-selected'),
 			iconBase: '',
 			tickIcon: select.data('selected-icon-check')
 		};
+
+		$('.selectpicker')
+			.removeClass('form-select form-select-sm')
+			.addClass('form-control form-control-sm')
+			.selectpicker('destroy')
+			.selectpicker({
+				iconBase: 'fa'
+			});
+
+		return defaults;
 	}
 };
 
 $(function() {
-	return datagridFitlerMultiSelect();
+	return datagridFilterMultiSelect();
 });
 
 datagridGroupActionMultiSelect = function() {
@@ -855,15 +865,7 @@ $(function() {
 
 dataGridRegisterExtension('datagrid.fitlerMultiSelect', {
 	success: function() {
-		datagridFitlerMultiSelect();
-		if ($.fn.selectpicker) {
-			return $('.selectpicker')
-				.removeClass('form-select form-select-sm')
-				.addClass('form-control form-control-sm')
-				.selectpicker({
-					iconBase: 'fa'
-				}).selectpicker('refresh');
-		}
+		datagridFilterMultiSelect();
 	}
 });
 


### PR DESCRIPTION
@radimvaculik prepared a workaround for filterMultiselect that ensured that the "form-select" and "form-select-sm" classes on selects are replaced with the "form-control" and "form-control-sm" ones. This ensures that the "duplicate borders" of the bootstrap-select disappears.

However, in the original implementation this was registered to the success event of the "datagrid.fitlerMultiSelect" extension registration. So if I understand the implementation correctly, the class replacement is only done when some naja/nette.ajax.js request succeeds. That's why the "duplicate borders" remained for me when the page was loaded without any interaction.

So I moved the replacement of these classes to the datagridFilterMultiSelect() function, which is called both on success event and on page load.

I also replaced the slectpicker('refresh') call with a selecpicker('destroy') and his new initialization pair (workaround for a bug in bootstrap-select - https://github.com/snapappointments/bootstrap-select/issues/2738 ).