### PR TITLE
Remove group action input requirement double translation

### DIFF
--- a/src/GroupAction/GroupActionCollection.php
+++ b/src/GroupAction/GroupActionCollection.php
@@ -103,7 +103,7 @@ class GroupActionCollection
 
 				$control->setAttribute('id', $lookupPath . self::ID_ATTRIBUTE_PREFIX . $id)
 					->addConditionOn($groupActionSelect, Form::EQUAL, $id)
-					->setRequired($translator->translate('ublaboo_datagrid.choose_input_required'))
+					->setRequired('ublaboo_datagrid.choose_input_required')
 					->endCondition();
 
 			} elseif ($action instanceof GroupTextareaAction) {
@@ -111,7 +111,7 @@ class GroupActionCollection
 
 				$control->setAttribute('id', $lookupPath . self::ID_ATTRIBUTE_PREFIX . $id)
 					->addConditionOn($groupActionSelect, Form::EQUAL, $id)
-					->setRequired($translator->translate('ublaboo_datagrid.choose_input_required'));
+					->setRequired('ublaboo_datagrid.choose_input_required');
 			}
 
 			if (isset($control)) {


### PR DESCRIPTION
The group action with text input (addGroupTextAction) makes an extra translation of message about required values. 
But the form has been already translated (function createComponentFilter in Datagrid.php calls setTranslator) so the final message is wrong.

This PR simply removes the extra translation.
