### PR TITLE
 Effective DataModel when used with Rest API based datasource

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -139,7 +139,6 @@ final class DataModel
 		 */
 		if ($paginatorComponent !== null) {
 			$paginator = $paginatorComponent->getPaginator();
-			$paginator->setItemCount($this->dataSource->getCount());
 
 			$this->dataSource->sort($sorting)->limit(
 				$paginator->getOffset(),
@@ -148,7 +147,10 @@ final class DataModel
 
 			$this->onAfterPaginated($this->dataSource);
 
-			return $this->dataSource->getData();
+			$data = $this->dataSource->getData();
+			$paginator->setItemCount($this->dataSource->getCount());
+
+			return $data;
 		}
 
 		return $this->dataSource->sort($sorting)->getData();


### PR DESCRIPTION
 When Datagrid is used with common database like data sources, it is common, that receiving total count for paging cost extra one query. When working with REST API datasource it is best practice that response for getting resource collection contains information about total count.

 For the purposes of creating query only offset and limit is necessary. The total count is necessary for two reasons. First is to show UI component with list of pages. Second to check if requested page number is not higher that collection maximum.

 The problem with current model is, that the order in witch get total count is received cost two calls on Rest API endpoint instead of one. I suggest to move call of getCount() method after getting data. When working with DB, it does not matter if the getCount() call is sooner or later with performance in mind.

 If this kind of change is too big BC break, another possibility would be to create interface for data model and enable change of DataModel. One will be more strict in terms of pagination overflow and another less.