### PR TITLE
Introducing interface for DataModel

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -31,7 +31,7 @@ use Ublaboo\DataGrid\Utils\Sorting;
  * @method onAfterFilter(IDataSource $dataSource)
  * @method onAfterPaginated(IDataSource $dataSource)
  */
-final class DataModel
+final class DataModel implements DataModelInterface
 {
 
 	use SmartObject;

--- a/src/DataModelInterface.php
+++ b/src/DataModelInterface.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+namespace Ublaboo\DataGrid;
+
+
+use Ublaboo\DataGrid\Components\DataGridPaginator\DataGridPaginator;
+use Ublaboo\DataGrid\DataSource\IDataSource;
+use Ublaboo\DataGrid\Utils\Sorting;
+
+/**
+ * @method onBeforeFilter(IDataSource $dataSource)
+ * @method onAfterFilter(IDataSource $dataSource)
+ * @method onAfterPaginated(IDataSource $dataSource)
+ */
+interface DataModelInterface
+{
+
+	public function getDataSource(): IDataSource;
+
+
+	public function filterData(?DataGridPaginator $paginatorComponent, Sorting $sorting, array $filters): iterable;
+
+
+	/**
+	 * @return mixed
+	 */
+	public function filterRow(array $condition);
+}

--- a/src/Exception/InitializingDataModelCallbacksException.php
+++ b/src/Exception/InitializingDataModelCallbacksException.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Ublaboo\DataGrid\Exception;
+
+use Throwable;
+
+class InitializingDataModelCallbacksException extends DataGridException
+{
+	public function __construct(?Throwable $previous = null)
+	{
+		parent::__construct("Cannot set callbacks before data model is set.", 0, $previous);
+	}
+}

--- a/src/RestBasedDataModel.php
+++ b/src/RestBasedDataModel.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Ublaboo\DataGrid;
+
+use Nette\SmartObject;
+use Ublaboo\DataGrid\Components\DataGridPaginator\DataGridPaginator;
+use Ublaboo\DataGrid\DataSource\IDataSource;
+use Ublaboo\DataGrid\Utils\Sorting;
+
+/**
+ * @method onBeforeFilter(IDataSource $dataSource)
+ * @method onAfterFilter(IDataSource $dataSource)
+ * @method onAfterPaginated(IDataSource $dataSource)
+ */
+final class RestBasedDataModel implements DataModelInterface
+{
+
+	use SmartObject;
+
+	/**
+	 * @var array|callable[]
+	 */
+	public $onBeforeFilter = [];
+
+	/**
+	 * @var array|callable[]
+	 */
+	public $onAfterFilter = [];
+
+	/**
+	 * @var array|callable[]
+	 */
+	public $onAfterPaginated = [];
+
+	/**
+	 * @var IDataSource
+	 */
+	private $dataSource;
+
+
+	public function __construct(IDataSource $source)
+	{
+		$this->dataSource = $source;
+	}
+
+
+	public function getDataSource(): IDataSource
+	{
+		return $this->dataSource;
+	}
+
+
+	public function filterData(
+		?DataGridPaginator $paginatorComponent,
+		Sorting $sorting,
+		array $filters
+	): iterable
+	{
+		$this->onBeforeFilter($this->dataSource);
+
+		$this->dataSource->filter($filters);
+
+		$this->onAfterFilter($this->dataSource);
+
+		/**
+		 * Paginator is optional
+		 */
+		if ($paginatorComponent !== null) {
+			$paginator = $paginatorComponent->getPaginator();
+
+			$this->dataSource->sort($sorting)->limit(
+				$paginator->getOffset(),
+				$paginator->getItemsPerPage()
+			);
+
+			$this->onAfterPaginated($this->dataSource);
+
+			$data = $this->dataSource->getData();
+			$paginator->setItemCount($this->dataSource->getCount());
+
+			return $data;
+		}
+
+		return $this->dataSource->sort($sorting)->getData();
+	}
+
+
+	/**
+	 * @return mixed
+	 */
+	public function filterRow(array $condition)
+	{
+		$this->onBeforeFilter($this->dataSource);
+		$this->onAfterFilter($this->dataSource);
+
+		return $this->dataSource->filterOne($condition)->getData();
+	}
+}


### PR DESCRIPTION
When Datagrid is used with common database like data sources, it is common, that receiving total count for paging cost extra one query. When working with REST API datasource it is best practice that response for getting resource collection contains information about total count.

For the purposes of creating query only offset and limit is necessary. The total count is necessary for two reasons. First is to show UI component with list of pages. Second to check if requested page number is not higher that collection maximum.

The problem with current model is, that the order in witch get total count is received cost two calls on Rest API endpoint instead of one. I suggest to move call of getCount() method after getting data. When working with DB, it does not matter if the getCount() call is sooner or later with performance in mind.

I have already created PR https://github.com/contributte/datagrid/pull/1037 but i`ve change my mind and created this PR.

DataModel now implements interface and Datagrid use interface instead of specific implementation. For purposes of REST based datasources i have created new DataModel where order of getCount method call is changed. 

If somebody wants to change datamodel, it can be done with new method `setDataModel`.