### PR TITLE
Fixing custom classes on checkbox in inline edit

### DIFF
--- a/src/InlineEdit/InlineEdit.php
+++ b/src/InlineEdit/InlineEdit.php
@@ -190,7 +190,7 @@ class InlineEdit
 					break;
 
 				default:
-					if ($control->getControl()->getAttribute('class') === null) {
+					if ($control->getControlPrototype()->getAttribute('class') === null) {
 						$control->setAttribute('class', 'form-control form-control-sm');
 					}
 


### PR DESCRIPTION
- `\Nette\Forms\Controls\Checkbox::getControl` returns label part and control part like one `\Nette\Utils\Html` and then `$control->getControl()->getAttribute('class')` is always null (because it takes class from label) and custom defined classes are always overwritten by `$control->setAttribute('class', 'form-control input-sm form-control-sm');`
- fixed by using `\Nette\Forms\Controls\BaseControl::getControlPrototype` which always returns only control part without label part