### PR TITLE
Cast datagrid-editable-value to string

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -687,7 +687,7 @@ $(document).on('click', '[data-datagrid-editable-url]', function(event) {
 		cell.addClass('editing');
 		cellValue = cell.html().trim().replace('<br>', '\n');
 		if (cell.attr('data-datagrid-editable-value')) {
-			valueToEdit = cell.data('datagrid-editable-value');
+			valueToEdit = String(cell.data('datagrid-editable-value'));
 		} else {
 			valueToEdit = cellValue;
 		}


### PR DESCRIPTION
There was a problem, when someone uses `setEditableValueCallback` on a row, and returns some string, but this string is for instance `123`, javascript casts that attribute to integer, and when you click away, callback is called because integer != string - datagrid thinks the value has changed.