### PR TITLE
Fix repeating of persistent parameter in url

### DIFF
--- a/assets/datagrid.js
+++ b/assets/datagrid.js
@@ -354,6 +354,9 @@ for(var p in obj) {
 	if (obj.hasOwnProperty(p)) {
 		var k = prefix ? prefix + "[" + p + "]" : p, v = obj[p];
 		if (v !== null && v !== "") {
+			if (window.location.pathname.includes('/' + v)) {
+				continue;
+			}
 			if (typeof v == "object") {
 				var r = window.datagridSerializeUrl(v, k);
 					if (r) {


### PR DESCRIPTION
When loading clean page with datagrid and persistent parameter included in router url, datagrid js always updated url and added redundant persistent parameter, for isntance:

url where example.com is persistent parameter `domainName` => `http://localhost/domain/example.com/cron-task`
would turn into `http://localhost/domain/example.com/cron-task?domainName=example.com`
because datagrid js has no way of knowing that there is already that persistent parameter.

In that case, my solution checks for `/example.com` in url, and if it's there, it skips that parameter while building url query, I think it's good enough when there is persistent parameter standalone somewhere in url.