### PR TITLE
Fix for searching id over array data source

### DIFF
--- a/src/DataSource/ArrayDataSource.php
+++ b/src/DataSource/ArrayDataSource.php
@@ -93,10 +93,7 @@ class ArrayDataSource implements IDataSource
 	{
 		foreach ($this->data as $item) {
 			foreach ($condition as $key => $value) {
-				if ($key === 'id' && is_string($value)) {
-					$value = intval($value);
-				}
-				if ($item[$key] === $value) {
+				if ($item[$key] == $value) {
 					$this->setData([$item]);
 
 					return $this;

--- a/src/DataSource/ArrayDataSource.php
+++ b/src/DataSource/ArrayDataSource.php
@@ -93,6 +93,9 @@ class ArrayDataSource implements IDataSource
 	{
 		foreach ($this->data as $item) {
 			foreach ($condition as $key => $value) {
+				if ($key === 'id' && is_string($value)) {
+					$value = intval($value);
+				}
 				if ($item[$key] === $value) {
 					$this->setData([$item]);
 


### PR DESCRIPTION
When condition for filterOne looks like `$condition = ['id' => '25661']; and object structure is ['id' => int, ...] item detail is not working correctly.


Thank you for your time
