### PR TITLE
Add support for `nette/utils` version `4.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"contributte/application": "^0.5.0",
 		"nette/di": "^3.0.0",
 		"nette/forms": "^3.1.3",
-		"nette/utils": "^3.0.1",
+		"nette/utils": "^3.0.1 || ^4.0.0",
 		"symfony/property-access": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,3 +48,19 @@ parameters:
 			message: "#^Parameter \\#1 \\$x of method Doctrine\\\\ORM\\\\Query\\\\Expr\\:\\:like\\(\\) expects string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Func given\\.$#"
 			count: 1
 			path: src/DataSource/DoctrineDataSource.php
+		- # In PHP 8+, the Stringable typehint should be used, and this can be removed.
+			message: '#string\\|Stringable#'
+			count: 1
+			path: src/Column/Action.php
+		- # In PHP 8+, the Stringable typehint should be used, and this can be removed.
+			message: '#string\\|Stringable#'
+			count: 1
+			path: src/DataGrid.php
+		- # In PHP 8+, the Stringable typehint should be used, and this can be removed.
+			message: '#string\\|Stringable#'
+			count: 3
+			path: src/Export/Export.php
+		- # In PHP 8+, the Stringable typehint should be used, and this can be removed.
+			message: '#string\\|Stringable#'
+			count: 2
+			path: src/Status/Option.php


### PR DESCRIPTION
This PR is adding support for `nette/utils` version `4.0.0`.

I went through all usages of `nette/utils` in the repository. It seems to be safe.

I did not know how to get rid of that PHPStan warnings related to the `\Stringable` interface which is used as a type hint in `nette/utils` other than ignore these warnings. We can not use `\Stringable` since we want to support PHP versions `<8`. Is there a better solution?