### PR TITLE
Fix timeout vs. number utils.ts

### DIFF
--- a/assets/utils.ts
+++ b/assets/utils.ts
@@ -120,7 +120,7 @@ export function debounce<TArgs, TFun extends (...args: TArgs[]) => unknown | Pro
 	fn: TFun,
 	slowdown: number = 200
 ): (...args: TArgs[]) => void {
-	let timeout: number | null = null;
+	let timeout: ReturnType<typeof setTimeout> | null = null;
 	let blockedByPromise: boolean = false;
 
 	return (...args) => {


### PR DESCRIPTION
Fix for this error during the build
[tsl] ERROR in /node_modules/ublaboo-datagrid/assets/utils.ts(130,3)
      TS2322: Type 'Timeout' is not assignable to type 'number'.