### PR TITLE
fix: resolution name for datagrid -> attribute instead of class

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -14,7 +14,7 @@
  * @param InlineEdit|null $inlineAdd   Inline add data
  *}
 
-<div class="{block datagrid-class}datagrid datagrid-{$control->getFullName()}{/block}" data-refresh-state="{link refreshState!}">
+<div {block datagrid-class}data-datagrid-{$control->getFullName()}{/block} data-refresh-state="{link refreshState!}">
 	<div n:snippet="grid">
 	{snippetArea gridSnippets}
 		{form filter, class => 'ajax'}


### PR DESCRIPTION
Fix for warning in developers console. ![image](https://github.com/contributte/datagrid/assets/33009282/df3cad22-df66-4305-947a-2cd8ab90515e)