### PR TITLE
Request values of inline add/edit containers only when this part of form is submitted

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -1262,8 +1262,6 @@ class Datagrid extends Control
 			return;
 		}
 
-		$values = (array) $form->getUntrustedValues(null);
-
 		if ($this->getPresenterInstance()->isAjax()) {
 			if (isset($form['group_action']['submit']) && $form['group_action']['submit']->isSubmittedBy()) {
 				return;
@@ -1273,9 +1271,11 @@ class Datagrid extends Control
 		/**
 		 * Per page
 		 */
-		if (isset($values['perPage'])) {
-			$this->saveSessionData('_grid_perPage', $values['perPage']);
-			$this->perPage = $values['perPage'];
+		$perPage = $form['perPage']->getValue();
+
+		if (isset($perPage)) {
+			$this->saveSessionData('_grid_perPage', $perPage);
+			$this->perPage = $perPage;
 		}
 
 		/**
@@ -1303,7 +1303,7 @@ class Datagrid extends Control
 				$primaryWhereColumn = $form->getHttpData(Form::DataLine, 'inline_edit[_primary_where_column]');
 
 				if ($edit['submit']->isSubmittedBy() && $edit->getErrors() === []) {
-					$this->inlineEdit->onSubmit($id, $values['inline_edit']);
+					$this->inlineEdit->onSubmit($id, $form['inline_edit']->getValues());
 					$this->getPresenterInstance()->payload->_datagrid_inline_edited = $id;
 					$this->getPresenterInstance()->payload->_datagrid_name = $this->getFullName();
 				} else {
@@ -1345,7 +1345,7 @@ class Datagrid extends Control
 
 			if ($add['submit']->isSubmittedBy() || $add['cancel']->isSubmittedBy()) {
 				if ($add['submit']->isSubmittedBy() && $add->getErrors() === []) {
-					$this->inlineAdd->onSubmit($values['inline_add']);
+					$this->inlineAdd->onSubmit($form['inline_add']->getValues());
 				}
 
 				$this->redrawControl('tbody');
@@ -1359,7 +1359,7 @@ class Datagrid extends Control
 		/**
 		 * Filter itself
 		 */
-		$values = $values['filter'];
+		$values = $form['filter']->getValues();
 
 		if (!$values instanceof ArrayHash) {
 			throw new UnexpectedValueException();

--- a/tests/Cases/FilterTest.phpt
+++ b/tests/Cases/FilterTest.phpt
@@ -5,8 +5,10 @@ namespace Contributte\Datagrid\Tests\Cases;
 require __DIR__ . '/../bootstrap.php';
 
 use Contributte\Datagrid\Datagrid;
+use Contributte\Datagrid\Tests\Files\FormValueObject;
 use Contributte\Datagrid\Tests\Files\TestingDatagridFactoryRouter;
 use Nette\Application\AbortException;
+use Nette\Forms\Container;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -21,6 +23,38 @@ final class FilterTest extends TestCase
 		$filterForm = $grid->createComponentFilter();
 
 		Assert::exception(function () use ($grid, $filterForm): void {
+			$grid->filterSucceeded($filterForm);
+		}, AbortException::class);
+	}
+
+	/**
+	 * This case is testing grid filter processing to not cause side effects by unnecessarily instantiating
+	 * value object {@see FormValueObject} of inline add form container. This value object is crafted
+	 * to fail on constructor argument type check due to inline add form container not being validated in this case.
+	 */
+	public function testFilterSubmitWithInvalidInlineAddOpen(): void
+	{
+		$factory = new TestingDataGridFactoryRouter();
+		/** @var \Ublaboo\DataGrid\Datagrid $grid */
+		$grid = $factory->createTestingDataGrid()->getComponent('grid');
+
+		$grid->addColumnText('status', 'Status');
+
+		$grid->addInlineAdd()->onControlAdd[] = function (Container $container) {
+			$container->setMappedType(FormValueObject::class);
+			$container->addSelect('status', '', [
+				// items are irrelevant, case is testing control returning null value
+				1 => 'Concept',
+				2 => 'Active',
+				3 => 'Unpublished',
+			])
+				->setPrompt('---')
+				->setRequired();
+		};
+
+		$filterForm = $grid->createComponentFilter();
+
+		Assert::exception(function() use ($grid, $filterForm): void {
 			$grid->filterSucceeded($filterForm);
 		}, AbortException::class);
 	}

--- a/tests/Files/FormValueObject.php
+++ b/tests/Files/FormValueObject.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contributte\Datagrid\Tests\Files;
+
+class FormValueObject
+{
+
+	public int $status;
+
+}


### PR DESCRIPTION
Inline add/edit form container can be mapped to object with required properties, so creation of this value object will fail when form controls are set as required but their validation is skipped by validation scope for example when grid filter is submitted.