### PR TITLE
Fix for wrong display of toolbar & export buttons

### DIFF
--- a/assets/datagrid.css
+++ b/assets/datagrid.css
@@ -67,12 +67,16 @@
 	display: inline-block
 }
 
-.datagrid .datagrid-toolbar > span {
+.datagrid .datagrid-toolbar > div > span {
 	margin-left: 1em
 }
 
-.datagrid .datagrid-toolbar > span > a {
+.datagrid .datagrid-toolbar > div > span > a {
 	margin-left: 0.5em
+}
+
+.datagrid .datagrid-toolbar > div {
+	display: inline-block
 }
 
 .datagrid-toolbar .fa-square, .datagrid-toolbar .fa-check-square {


### PR DESCRIPTION
See issue #1101
### Summary
After commit 55fd8b4 the toolbar looks wrong:

![image](https://github.com/contributte/datagrid/assets/24586123/ba4c5c31-e184-43bf-8015-779718f1f82c)

1. The buttons are without any space between - this is because of wrong CSS selector in datagrid.css - extra div is now needed - fixed by modifying CSS selector
2. The export buttons are on new line - this is because of the new snippet div (the export toolbar is outside of it) - fixed by CSS property display of new div set to inline-block

After these changes, toolbar looks better:

![image](https://github.com/contributte/datagrid/assets/24586123/46de41a5-ae68-494b-9911-40c6d79b2dfb)

