### PR TITLE
Allow coexistence of both outer and column filters

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -313,6 +313,7 @@ class DataGrid extends Control
 
 	/**
 	 * @var bool
+     * @deprecated 
 	 */
 	protected $outerFilterRendering = false;
 
@@ -1636,11 +1637,19 @@ class DataGrid extends Control
 		$this->reload();
 	}
 
+
 	/**
 	 * @return static
 	 */
 	public function setOuterFilterRendering(bool $outerFilterRendering = true): self
 	{
+        $this->onFiltersAssembled['setOuterFilterRendering'] = function (iterable $filters) use ($outerFilterRendering) {
+            /** @var Filter $filter */
+            foreach ($filters as $filter) {
+                $filter->setOuterRendering($outerFilterRendering);
+            }
+        };
+        
 		$this->outerFilterRendering = $outerFilterRendering;
 
 		return $this;
@@ -1649,8 +1658,26 @@ class DataGrid extends Control
 
 	public function hasOuterFilterRendering(): bool
 	{
-		return $this->outerFilterRendering;
+        foreach ($this->filters as $filter) {
+            if ($filter->hasOuterRendering()) {
+                return true;
+            }
+        }
+
+		return false;
 	}
+
+
+    public function hasColumnFilterRendering(): bool
+    {
+        foreach ($this->filters as $filter) {
+            if (!$filter->hasOuterRendering()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 
 	/**

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -313,7 +313,7 @@ class DataGrid extends Control
 
 	/**
 	 * @var bool
-     * @deprecated 
+     * @deprecated
 	 */
 	protected $outerFilterRendering = false;
 
@@ -1643,13 +1643,13 @@ class DataGrid extends Control
 	 */
 	public function setOuterFilterRendering(bool $outerFilterRendering = true): self
 	{
-        $this->onFiltersAssembled['setOuterFilterRendering'] = function (iterable $filters) use ($outerFilterRendering) {
-            /** @var Filter $filter */
-            foreach ($filters as $filter) {
-                $filter->setOuterRendering($outerFilterRendering);
-            }
-        };
-        
+		$this->onFiltersAssembled['setOuterFilterRendering'] = function (iterable $filters) use ($outerFilterRendering) {
+			/** @var Filter $filter */
+			foreach ($filters as $filter) {
+				$filter->setOuterRendering($outerFilterRendering);
+			}
+		};
+
 		$this->outerFilterRendering = $outerFilterRendering;
 
 		return $this;
@@ -1658,26 +1658,26 @@ class DataGrid extends Control
 
 	public function hasOuterFilterRendering(): bool
 	{
-        foreach ($this->filters as $filter) {
-            if ($filter->hasOuterRendering()) {
-                return true;
-            }
-        }
+		foreach ($this->filters as $filter) {
+			if ($filter->hasOuterRendering()) {
+				return true;
+			}
+		}
 
 		return false;
 	}
 
 
-    public function hasColumnFilterRendering(): bool
-    {
-        foreach ($this->filters as $filter) {
-            if (!$filter->hasOuterRendering()) {
-                return true;
-            }
-        }
+	public function hasColumnFilterRendering(): bool
+	{
+		foreach ($this->filters as $filter) {
+			if (!$filter->hasOuterRendering()) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
 
 	/**

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -61,10 +61,10 @@ abstract class Filter
 		'class' => ['form-control', 'input-sm', 'form-control-sm'],
 	];
 
-    /**
-     * @var bool
-     */
-    protected $outerRendering = false;
+	/**
+	 * @var bool
+	 */
+	protected $outerRendering = false;
 
 	/**
 	 * @var string|null
@@ -197,21 +197,21 @@ abstract class Filter
 	}
 
 
-    /**
-     * @return static
-     */
-    public function setOuterRendering(bool $outerRendering = true): self
-    {
-        $this->outerRendering = $outerRendering;
+	/**
+	 * @return static
+	 */
+	public function setOuterRendering(bool $outerRendering = true): self
+	{
+		$this->outerRendering = $outerRendering;
 
-        return $this;
-    }
+		return $this;
+	}
 
 
-    public function hasOuterRendering(): bool
-    {
-        return $this->outerRendering;
-    }
+	public function hasOuterRendering(): bool
+	{
+		return $this->outerRendering;
+	}
 
 
 	/**

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -61,6 +61,11 @@ abstract class Filter
 		'class' => ['form-control', 'input-sm', 'form-control-sm'],
 	];
 
+    /**
+     * @var bool
+     */
+    protected $outerRendering = false;
+
 	/**
 	 * @var string|null
 	 */
@@ -190,6 +195,23 @@ abstract class Filter
 	{
 		return $this->type;
 	}
+
+
+    /**
+     * @return static
+     */
+    public function setOuterRendering(bool $outerRendering = true): self
+    {
+        $this->outerRendering = $outerRendering;
+
+        return $this;
+    }
+
+
+    public function hasOuterRendering(): bool
+    {
+        return $this->outerRendering;
+    }
 
 
 	/**

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -40,7 +40,7 @@
 							{var $i = 0}
 							{var $filterColumnsClass = 'col-sm-' . (12 / $control->getOuterFilterColumnsCount())}
 							<div class="datagrid-row-outer-filters-group {$filterColumnsClass}" n:foreach="$filters as $f">
-							    {continueIf !$f->hasOuterRendering()}
+								{continueIf !$f->hasOuterRendering()}
 
 								{**
 								 * Each fitler is rendered separately in its own template

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -40,6 +40,8 @@
 							{var $i = 0}
 							{var $filterColumnsClass = 'col-sm-' . (12 / $control->getOuterFilterColumnsCount())}
 							<div class="datagrid-row-outer-filters-group {$filterColumnsClass}" n:foreach="$filters as $f">
+							    {continueIf !$f->hasOuterRendering()}
+
 								{**
 								 * Each fitler is rendered separately in its own template
 								 *}
@@ -138,7 +140,7 @@
 						</th>
 					</tr>
 					<tr n:block="header-column-row">
-						<th n:snippet="thead-group-action" n:if="$hasGroupActions" n:attr="'rowspan=2' => !empty($filters) && !$control->hasOuterFilterRendering()" class="col-checkbox">
+						<th n:snippet="thead-group-action" n:if="$hasGroupActions" n:attr="'rowspan=2' => !empty($filters) && $control->hasColumnFilterRendering()" class="col-checkbox">
 							<input n:if="$hasGroupActionOnRows" n:class="$control->shouldUseHappyComponents() ? 'happy gray-border' , primary" name="{$control->getFullName()|lower}-toggle-all" type="checkbox" data-check="{$control->getFullName()}" data-check-all="{$control->getFullName()}">
 						</th>
 						{foreach $columns as $key => $column}
@@ -196,12 +198,12 @@
 							{='ublaboo_datagrid.action'|translate}
 						</th>
 					</tr>
-					<tr n:block="header-filters" n:if="!empty($filters) && !$control->hasOuterFilterRendering()">
+					<tr n:block="header-filters" n:if="!empty($filters) && $control->hasColumnFilterRendering()">
 						{foreach $columns as $key => $column}
 							{var $th = $column->getElementForRender('th', $key)}
 							{$th->startTag()|noescape}
 							{var $col_header = 'col-filter-' . $key . '-header'}
-							{if !$control->hasOuterFilterRendering() && isset($filters[$key])}
+							{if isset($filters[$key]) && !$filters[$key]->hasOuterRendering()}
 								{var $i = $filter['filter'][$key]}
 
 									{var $filter_block = 'filter-' . $filters[$key]->getKey()}
@@ -221,7 +223,7 @@
 							{$th->endTag()|noescape}
 						{/foreach}
 						<th n:if="$actions || $control->isSortable() || $itemsDetail || $inlineEdit || $inlineAdd" class="col-action text-center">
-							{if !$control->hasAutoSubmit() && !$control->hasOuterFilterRendering()}
+							{if !$control->hasAutoSubmit() && $control->hasColumnFilterRendering()}
 								{input $filter['filter']['submit']}
 							{/if}
 						</th>

--- a/tests/Cases/FilterTest.phpt
+++ b/tests/Cases/FilterTest.phpt
@@ -10,6 +10,7 @@ use Nette\Application\AbortException;
 use Tester\Assert;
 use Tester\TestCase;
 use Ublaboo\DataGrid\DataGrid;
+use Ublaboo\DataGrid\Tests\Files\TestingDataGridFactory;
 use Ublaboo\DataGrid\Tests\Files\TestingDataGridFactoryRouter;
 
 final class FilterTest extends TestCase
@@ -25,6 +26,37 @@ final class FilterTest extends TestCase
 		Assert::exception(function() use ($grid, $filterForm): void {
 			$grid->filterSucceeded($filterForm);
 		}, AbortException::class);
+	}
+
+	public function testFilterRendering(): void
+	{
+		$factory = new TestingDataGridFactory();
+		/** @var DataGrid $grid */
+		$grid = $factory->createTestingDataGrid();
+
+		$grid->addFilterText('default', 'default');
+		$grid->assembleFilters();
+		Assert::false($grid->hasOuterFilterRendering());
+		Assert::true($grid->hasColumnFilterRendering());
+
+		$grid->setOuterFilterRendering();
+		$grid->assembleFilters();
+		Assert::true($grid->hasOuterFilterRendering());
+		Assert::false($grid->hasColumnFilterRendering());
+
+		$grid->removeFilter('default');
+		$filters = $grid->assembleFilters();
+		Assert::count(0, $filters);
+
+		$grid->addFilterText('outerFilter', 'outerFilter')
+			->setOuterRendering();
+		$grid->assembleFilters();
+		Assert::true($grid->hasOuterFilterRendering());
+		Assert::false($grid->hasColumnFilterRendering());
+
+		$grid->addFilterText('columnFilter', 'columnFilter');
+		Assert::true($grid->hasOuterFilterRendering());
+		Assert::true($grid->hasColumnFilterRendering());
 	}
 
 }


### PR DESCRIPTION
Hello, we are using Datagrid on quite large project with millions of records. And we have currently reached some limitations that causes us some issues. 

We would like to create the grid overview of the users. We have currently about 800k business users. Each user can have n invoicing addresses among others (same can be applied to more records, like contacts, delivery addresses and so on). The grid displays only data from user (other entities are accessible through user detail). We need, however, to filter users based on data in their subentities. The example could be a user calling to callcenter providing their ID number (IČO) which is attribute of invoicing address. 

Datagrid allows us to use either column filters or outer filters. Keeping the columns would require to add column with ID values (probably using GROUP_CONCAT(DISTINCT)). Using outer filters would allow to add the filter we require, but it would also move all filters from columns, which isn't the desired operation as column filters are very useful. 

This PR moves rendering decision down to filter instead of keeping it on DataGrid level. The change allows to keep column filters while also add a possibility to create a detached filter that would only be added to the section over the grid. The code and its execution should be compatible with previous version, so is should be safe to deploy within next minor version. 

Example:
```php
$grid->addFilterText('ico', 'IČO')
    ->setOuterRendering()
    ->setCondition(function (Fluent $fluent, $value): void {
        if ($value) {
            $fluent->where([['invoice_address.ic = %i', $value]]);
        }
    });
```