### PR TITLE
Fix getCount for ElasticsearchDataSource

### DIFF
--- a/src/DataSource/ElasticsearchDataSource.php
+++ b/src/DataSource/ElasticsearchDataSource.php
@@ -49,15 +49,13 @@ class ElasticsearchDataSource extends FilterableDataSource implements IDataSourc
 
 	public function getCount(): int
 	{
-		$searchResult = $this->client->search($this->searchParamsBuilder->buildParams());
+		$searchResult = $this->client->count($this->searchParamsBuilder->buildParams());
 
-		if (!isset($searchResult['hits'])) {
-			throw new \UnexpectedValueException;
-		}
+	        if (!isset($searchResult['count'])) {
+	            throw new \UnexpectedValueException;
+	        }
 
-		return is_array($searchResult['hits']['total'])
-			? $searchResult['hits']['total']['value']
-			: $searchResult['hits']['total'];
+        	return $searchResult['count'];
 	}
 
 


### PR DESCRIPTION
fix getCount for Elastic to achieve grid with +10k records when index's max_result_window is appropriately set