### PR TITLE
fixed compatibility with nette/component-model 3.1

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -446,8 +446,6 @@ class DataGrid extends Control
 			$parent->addComponent($this, $name);
 		}
 
-		$this->monitor('Nette\Application\UI\Presenter');
-
 		/**
 		 * Try to find previous filters, pagination, perPage and other values in session
 		 */


### PR DESCRIPTION
I think that line in there is completely unnecessary.