### PR TITLE
Update datagrid.latte - HTML attribute class missing

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -14,7 +14,7 @@
  * @param InlineEdit|null $inlineAdd   Inline add data
  *}
 
-<div {block datagrid-class}{/block}data-datagrid-name="{$control->getFullName()}" data-refresh-state="{link refreshState!}">
+<div class="{block datagrid-class}{/block}" data-datagrid-name="{$control->getFullName()}" data-refresh-state="{link refreshState!}">
 	<div n:snippet="grid">
 	{snippetArea gridSnippets}
 		{form filter, class => 'ajax'}


### PR DESCRIPTION
Fix for 

```
Latte\RuntimeException

Overridden block datagrid-class with content type HTML/TAG by incompatible type HTML.
```