### PR TITLE
Expect return of new collection from custom sorting callback in NextrasDataSource

### DIFF
--- a/src/DataSource/NextrasDataSource.php
+++ b/src/DataSource/NextrasDataSource.php
@@ -72,7 +72,7 @@ class NextrasDataSource extends FilterableDataSource implements IDataSource, IAg
 	public function sort(Sorting $sorting): IDataSource
 	{
 		if (is_callable($sorting->getSortCallback())) {
-			call_user_func(
+			$this->dataSource = call_user_func(
 				$sorting->getSortCallback(),
 				$this->dataSource,
 				$sorting->getSort()


### PR DESCRIPTION
Nextras ORM collection are immutable. In custom sortable callback (set by `setSortableCallback`) we would typically call `orderBy` on the collection passed in first argument. But it would have no effect on the original collection in `NextrasDataSource`.

Example:

This would have no effect on ordering:

```php
$grid->addColumnText('program', 'Program')->setSortable()->setSortableCallback(function (DbalCollection $collection, array $sorting) {
	$collection
		->resetOrderBy()
		->orderBy(['isElective' => $sorting['program'], 'program->name' => $sorting['program']]);
});
``` 

Before the suggested change, this would also have no effect on ordering.
But after the suggested change, this would achieve intended result:

```php
$grid->addColumnText('program', 'Program')->setSortable()->setSortableCallback(function (DbalCollection $collection, array $sorting) {
	return $collection
		->resetOrderBy()
		->orderBy(['isElective' => $sorting['program'], 'program->name' => $sorting['program']]);
});
``` 

