### PR TITLE
handleShowColumn crash when all columns are shown

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -2046,7 +2046,7 @@ class Datagrid extends Control
 	{
 		$columns = $this->getSessionData('_grid_hidden_columns');
 
-		if ($columns !== []) {
+		if ($columns !== [] && $columns !== null) {
 			$pos = array_search($column, $columns, true);
 
 			if ($pos !== false) {


### PR DESCRIPTION
array_search(): Argument #2 ($haystack) must be of type array, null given