### PR TITLE
fix: adding multiple listeners to the same element

### DIFF
--- a/assets/plugins/features/autosubmit.ts
+++ b/assets/plugins/features/autosubmit.ts
@@ -46,6 +46,11 @@ export class AutosubmitPlugin implements DatagridPlugin {
 				const form = submitEl.closest("form");
 				if (!form) return;
 
+				if (submitEl.dataset.listenersAttached === "true") {
+					return; // Skip if listeners are already attached
+				}
+				submitEl.dataset.listenersAttached = "true";
+
 				// Select auto-submit
 				if (submitEl instanceof HTMLSelectElement) {
 					submitEl.addEventListener("change", () => datagrid.ajax.submitForm(form));

--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -13,7 +13,6 @@ use Contributte\Datagrid\Filter\FilterSelect;
 use Contributte\Datagrid\Filter\FilterText;
 use Contributte\Datagrid\Utils\DateTimeHelper;
 use Contributte\Datagrid\Utils\Sorting;
-use dibi;
 use Dibi\Fluent;
 use Dibi\Helpers;
 use ReflectionClass;
@@ -167,7 +166,7 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 		$or = [];
 
 		foreach ($condition as $column => $value) {
-			$column = Helpers::escape($driver, $column, dibi::IDENTIFIER);
+			$column = Helpers::escape($driver, $column, Fluent::Identifier);
 
 			if ($filter->isExactSearch()) {
 				$this->dataSource->where(sprintf('%s = %%s', $column), $value);

--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -7,7 +7,6 @@ use Contributte\Datagrid\Filter\FilterDate;
 use Contributte\Datagrid\Filter\FilterDateRange;
 use Contributte\Datagrid\Filter\FilterText;
 use Contributte\Datagrid\Utils\DateTimeHelper;
-use dibi;
 use Dibi\Fluent;
 use Dibi\Helpers;
 use Dibi\Result;
@@ -108,7 +107,7 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 		$or = [];
 
 		foreach ($condition as $column => $value) {
-			$column = Helpers::escape($driver, $column, dibi::IDENTIFIER);
+			$column = Helpers::escape($driver, $column, Fluent::Identifier);
 
 			if ($filter->isExactSearch()) {
 				$this->dataSource->where(sprintf('%s = %%s', $column), $value);


### PR DESCRIPTION
I had an issue where there was a timeout when using filters.

![image](https://github.com/user-attachments/assets/948224c1-51ff-4b9c-ad22-8442451bdb49)

Each row on next image is added on single keypress
![image](https://github.com/user-attachments/assets/aa226cab-a0ac-4de2-9a62-9dcd3d171ad3)

![image](https://github.com/user-attachments/assets/d9a1dbe3-a980-4683-aff0-bf3e235268db)

The reason was that the Event listener was added again with every request.



