### PR TITLE
Reset filter buttons

### DIFF
--- a/assets/datagrid.ts
+++ b/assets/datagrid.ts
@@ -78,23 +78,27 @@ export class Datagrid extends EventTarget {
 		this.ajax.addEventListener("success", ({detail: {payload}}) => {
 			// todo: maybe move?
 			if (payload._datagrid_name && payload._datagrid_name === this.name) {
-				this.el.querySelector<HTMLElement>("[data-datagrid-reset-filter-by-column]")
-					?.classList.add("hidden");
+				const getColumnName = (el: HTMLElement) => el.getAttribute(
+					"data-datagrid-reset-filter-by-column"
+				)
 
-				if (payload.non_empty_filters && payload.non_empty_filters.length >= 1) {
-					const resets = Array.from<HTMLElement>(this.el.querySelectorAll(
-						`[data-datagrid-reset-filter-by-column]`
-					));
+				const resets = Array.from<HTMLElement>(this.el.querySelectorAll(
+					`[data-datagrid-reset-filter-by-column]`
+				));
 
-					const getColumnName = (el: HTMLElement) => el.getAttribute(
-						"data-datagrid-reset-filter-by-column"
-					)
+				const nonEmptyFilters = payload.non_empty_filters ? payload.non_empty_filters : [] as string[];
 
-					/// tf?
-					for (const columnName of payload.non_empty_filters) {
-						resets.find(getColumnName)?.classList.remove("hidden");
+				resets.forEach((el) => {
+					const columnName = getColumnName(el);
+
+					if (columnName && nonEmptyFilters.includes(columnName)) {
+						el.classList.remove("hidden");
+					} else {
+						el.classList.add("hidden");
 					}
+				});
 
+				if (nonEmptyFilters.length > 0) {
 					const href = this.el.querySelector(".reset-filter")
 						?.getAttribute("href");
 


### PR DESCRIPTION
Fixed showing of reset buttons for filters.

Hiding and showing of the reset button was working only for the first field. When entered some text into 2nd field, the button was shown for 1st field. When deleted the text from 2nd field (and kept text in 1st field) the reset button for 1st field was hidden.