### PR TITLE
Fix type error in str_replace in StringConfirmation of ColumnStatus/Option

### DIFF
--- a/src/Status/Option.php
+++ b/src/Status/Option.php
@@ -169,7 +169,7 @@ class Option
 
 			return str_replace(
 				'%s',
-				$row->getValue($this->confirmation->getPlaceholderName()),
+				(string) $row->getValue($this->confirmation->getPlaceholderName()),
 				$question
 			);
 		}


### PR DESCRIPTION
PHP8+ will raise an error in case of a non-string column used for StringConfirmation in ColumnStatus Status\Option.

Error: str_replace(): Argument #2 ($replace) must be of type array|string, int given

Code to reproduce:
```
$grid->addColumnStatus('active', 'Stav')
     ->addOption('on', 'On')
     ->setConfirmation(new StringConfirmation('Enable "%s"?', 'number'));
```

Related issued #943 - fixed the same error in grid Actions.