### PR TITLE
fix confirmation message cancel button

### DIFF
--- a/assets/ajax/naja.ts
+++ b/assets/ajax/naja.ts
@@ -77,10 +77,17 @@ export class NajaAjax<C extends Naja = Naja, G extends Datagrid = Datagrid> exte
 				throw new Error("Element is not an instanceof HTMLElement");
 			}
 
-			return this.dispatch('interact', {
+			const dispatchResult = this.dispatch('interact', {
 				...e.detail,
 				element: e.detail.element as HTMLElement // Naja's event has a type of HTMLElement
-			})
+			});
+
+			if (!dispatchResult) {
+				e.stopPropagation();
+				e.preventDefault();
+			}
+
+			return dispatchResult;
 		})
 
 
@@ -122,7 +129,11 @@ export class NajaAjax<C extends Naja = Naja, G extends Datagrid = Datagrid> exte
 	dispatch<
 		K extends string, M extends BaseAjaxEventMap = AjaxEventMap
 	>(type: K, detail: K extends keyof M ? EventDetail<M[K]> : any, options?: boolean): boolean {
-		return this.dispatchEvent(new CustomEvent(type, {detail}));
+		return this.dispatchEvent(new CustomEvent(type, {
+			detail: detail,
+			cancelable: true,
+		}));
+
 	}
 
 	declare addEventListener: <K extends keyof M, M extends BaseAjaxEventMap = AjaxEventMap>(


### PR DESCRIPTION
The Cancel button in pop-up messages is not functioning correctly. Instead of canceling the action or closing the pop-up, it performs the same action as the OK button.

![image](https://github.com/user-attachments/assets/ec8878e9-ccf1-4aa5-9e0a-4c3be41bc64d)


![image](https://github.com/user-attachments/assets/ec3727bf-6825-46ce-a4cc-7ac10708d9f1)
