### PR TITLE
:bug: Correct attribute name for sortable URL retrieval.

### DIFF
--- a/assets/integrations/sortable-js.ts
+++ b/assets/integrations/sortable-js.ts
@@ -23,7 +23,7 @@ export class SortableJS implements SortableInterface {
 							let componentPrefix = tbody.getAttribute("data-sortable-parent-path") ?? '';
 							if (componentPrefix.length) componentPrefix = `${componentPrefix}-`;
 
-							const url = tbody.getAttribute("sortable-ul") ?? "?do=sort";
+							const url = tbody.getAttribute("data-sortable-url") ?? "?do=sort";
 
 							const data = {
 								[`${componentPrefix}item_id`]: itemId,


### PR DESCRIPTION
There was a problem retrieving attribute value for the sortable URL handler, caused by a misspelling.