### PR TITLE
Refactor session handling to use pluggable state storage

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -268,9 +268,9 @@ class Datagrid extends Control
 
 	private ?string $componentFullName = null;
 
-    protected ?IStateStorage $stateStorage = null; // State storage for the datagrid
+	protected ?IStateStorage $stateStorage = null; // State storage for the datagrid
 
-    public function __construct(?IContainer $parent = null, ?string $name = null)
+	public function __construct(?IContainer $parent = null, ?string $name = null)
 	{
 		if ($parent !== null) {
 			$parent->addComponent($this, $name);
@@ -319,23 +319,23 @@ class Datagrid extends Control
 		);
 	}
 
-    public function getStateStorage(): IStateStorage
-    {
-        if ($this->stateStorage === null) {
-            return $this->rememberState || $this->canHideColumns()
-                ? new SessionStateStorage($this->gridSession)
-                : new NoopStateStorage();
-        }
+	public function getStateStorage(): IStateStorage
+	{
+		if ($this->stateStorage === null) {
+			return $this->rememberState || $this->canHideColumns()
+				? new SessionStateStorage($this->gridSession)
+				: new NoopStateStorage();
+		}
 
-        return $this->stateStorage;
-    }
+		return $this->stateStorage;
+	}
 
-    public function setStateStorage(IStateStorage $stateStorage): self
-    {
-        $this->stateStorage = $stateStorage;
+	public function setStateStorage(IStateStorage $stateStorage): self
+	{
+		$this->stateStorage = $stateStorage;
 
-        return $this;
-    }
+		return $this;
+	}
 
 
 	/********************************************************************************
@@ -547,9 +547,9 @@ class Datagrid extends Control
 	 *                                   SORTING *
 	 ********************************************************************************/
 
- /**
-  * @return static
-  */
+	/**
+	 * @return static
+	 */
 	public function setDefaultSort(string|array $sort, bool $useOnReset = true): self
 	{
 		$sort = is_string($sort)
@@ -1138,11 +1138,11 @@ class Datagrid extends Control
 			$this->filter = $this->defaultFilter;
 		}
 
-		$storedFilter = $this->getFilterSessionData();
+		$storedFilters = $this->getSessionData('_grid_filters', []);
 		foreach ($this->filter as $key => $value) {
-			$storedFilter[(string) $key] = $value;
+			$storedFilters[(string) $key] = $value;
 		}
-		$this->saveFilterSessionData($storedFilter);
+		$this->saveSessionData('_grid_filters', $storedFilters);
 	}
 
 	public function createComponentFilter(): Form
@@ -1390,7 +1390,7 @@ class Datagrid extends Control
 			throw new UnexpectedValueException();
 		}
 
-		$storedFilters = $this->getFilterSessionData();
+		$storedFilters = $this->getSessionData('_grid_filters', []);
 		foreach ($values as $key => $value) {
 			/**
 			 * Session stuff
@@ -1410,7 +1410,7 @@ class Datagrid extends Control
 			 */
 			$this->filter[$key] = $value;
 		}
-		$this->saveFilterSessionData($storedFilters);
+		$this->saveSessionData('_grid_filters', $storedFilters);
 
 		if ($values->count() > 0) {
 			$this->saveSessionData('_grid_has_filtered', 1);
@@ -1520,7 +1520,7 @@ class Datagrid extends Control
 			$this->sort = $sort;
 		}
 
-		foreach ($this->getFilterSessionData() as $key => $value) {
+		foreach ($this->getSessionData('_grid_filters', []) as $key => $value) {
 			try {
 				$this->getFilter($key);
 
@@ -2333,44 +2333,24 @@ class Datagrid extends Control
 		return $this;
 	}
 
-	public function getSessionData(?string $key = null, mixed $defaultValue = null): mixed
+	public function getSessionData(string $key, mixed $defaultValue = null): mixed
 	{
-        $value = $key !== null ? $this->getStateStorage()->loadState($key) : $defaultValue;
-
-		if ($this->rememberState) {
-			return $value;
-		}
-
-		if ($this->rememberHideableColumnsState && in_array($key, self::HIDEABLE_COLUMNS_SESSION_KEYS, true)) {
-			return $value;
-		}
-
-		return $key ?? $defaultValue;
+		return $this->getStateStorage()->loadState($key) ?? $defaultValue;
 	}
-	public function getFilterSessionData(): array
-	{
-		return $this->getSessionData('_grid_filters', []);
-	}
-
-	public function saveFilterSessionData(array $filters): void
-	{
-		$this->saveSessionData('_grid_filters', $filters);
-	}
-
 
 	public function saveSessionData(string $key, mixed $value): void
 	{
 		if ($this->rememberState) {
-            $this->getStateStorage()->saveState($key, $value);
+			$this->getStateStorage()->saveState($key, $value);
 		} elseif ($this->rememberHideableColumnsState && in_array($key, self::HIDEABLE_COLUMNS_SESSION_KEYS, true)) {
-            $this->getStateStorage()->saveState($key, $value);
+			$this->getStateStorage()->saveState($key, $value);
 		}
 	}
 
 	public function deleteSessionData(string $key): void
 	{
 		//unset($this->gridSession[$key]);
-        $this->getStateStorage()->deleteState($key);
+		$this->getStateStorage()->deleteState($key);
 	}
 
 
@@ -2938,8 +2918,8 @@ class Datagrid extends Control
 			);
 		}
 	}/********************************************************************************
-	  *                                    FILTERS *
-	  ********************************************************************************/
+ *                                    FILTERS *
+ ********************************************************************************/
 
 	/**
 	 * Check whether given key already exists in $this->filters

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -2335,21 +2335,27 @@ class Datagrid extends Control
 
 	public function getSessionData(string $key, mixed $defaultValue = null): mixed
 	{
-		return $this->getStateStorage()->loadState($key) ?? $defaultValue;
+		if ($this->shouldRememberState($key)) {
+			return $this->getStateStorage()->loadState($key) ?? $defaultValue;
+		}
+		return $defaultValue;
 	}
 
 	public function saveSessionData(string $key, mixed $value): void
 	{
-		if ($this->rememberState) {
-			$this->getStateStorage()->saveState($key, $value);
-		} elseif ($this->rememberHideableColumnsState && in_array($key, self::HIDEABLE_COLUMNS_SESSION_KEYS, true)) {
+		if ($this->shouldRememberState($key)) {
 			$this->getStateStorage()->saveState($key, $value);
 		}
 	}
 
+	private function shouldRememberState(string $key): bool
+	{
+		return $this->rememberState ||
+			($this->rememberHideableColumnsState && in_array($key, self::HIDEABLE_COLUMNS_SESSION_KEYS, true));
+	}
+
 	public function deleteSessionData(string $key): void
 	{
-		//unset($this->gridSession[$key]);
 		$this->getStateStorage()->deleteState($key);
 	}
 

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -1398,7 +1398,6 @@ class Datagrid extends Control
 		if (!$values instanceof ArrayHash) {
 			throw new UnexpectedValueException();
 		}
-
 		$storedFilters = $this->getStorageData('_grid_filters', []);
 		foreach ($values as $key => $value) {
 			/**

--- a/src/Storage/IStateStorage.php
+++ b/src/Storage/IStateStorage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\Datagrid\Storage;
+
+interface IStateStorage
+{
+    public function loadState(string $key): mixed;
+    public function saveState(string $key, mixed $value): void;
+    public function deleteState(string $key): void;
+    public function hasState(string $key): bool;
+}

--- a/src/Storage/IStateStorage.php
+++ b/src/Storage/IStateStorage.php
@@ -9,5 +9,4 @@ interface IStateStorage
     public function loadState(string $key): mixed;
     public function saveState(string $key, mixed $value): void;
     public function deleteState(string $key): void;
-    public function hasState(string $key): bool;
 }

--- a/src/Storage/NoopStateStorage.php
+++ b/src/Storage/NoopStateStorage.php
@@ -24,9 +24,4 @@ class NoopStateStorage implements IStateStorage
     {
         // Do nothing
     }
-
-    public function hasState(string $key): bool
-    {
-        return false; // Always returns false, as nothing is stored
-    }
 }

--- a/src/Storage/NoopStateStorage.php
+++ b/src/Storage/NoopStateStorage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\Datagrid\Storage;
+
+/**
+ * A "No-Operation" state storage that does nothing.
+ * Useful when persistence is not required.
+ */
+class NoopStateStorage implements IStateStorage
+{
+    public function loadState(string $key): mixed
+    {
+        return null; // Always returns null, as nothing is stored
+    }
+
+    public function saveState(string $key, mixed $value): void
+    {
+        // Do nothing
+    }
+
+    public function deleteState(string $key): void
+    {
+        // Do nothing
+    }
+
+    public function hasState(string $key): bool
+    {
+        return false; // Always returns false, as nothing is stored
+    }
+}

--- a/src/Storage/SessionStateStorage.php
+++ b/src/Storage/SessionStateStorage.php
@@ -32,9 +32,4 @@ class SessionStateStorage implements IStateStorage
     {
         $this->sessionSection->remove($key);
     }
-
-    public function hasState(string $key): bool
-    {
-        return $this->sessionSection->offsetExists($key);
-    }
 }

--- a/src/Storage/SessionStateStorage.php
+++ b/src/Storage/SessionStateStorage.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\Datagrid\Storage;
+
+use Nette\Http\SessionSection;
+
+/**
+ * SessionGridStateStorage is a storage for grid state that uses session to persist data.
+ * It implements the IGridStateStorage interface.
+ */
+class SessionStateStorage implements IStateStorage
+{
+
+    public function __construct(
+        private SessionSection $sessionSection)
+    {
+    }
+
+    public function loadState(string $key): mixed
+    {
+        return $this->sessionSection->get($key);
+    }
+
+    public function saveState(string $key, mixed $value): void
+    {
+        $this->sessionSection->set($key, $value);
+    }
+
+    public function deleteState(string $key): void
+    {
+        $this->sessionSection->remove($key);
+    }
+
+    public function hasState(string $key): bool
+    {
+        return $this->sessionSection->offsetExists($key);
+    }
+}

--- a/tests/Cases/RememberStateTest.phpt
+++ b/tests/Cases/RememberStateTest.phpt
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Contributte\Datagrid\Tests\Cases;
+require __DIR__ . '/../bootstrap.php';
+
+use Contributte\Datagrid\Datagrid;
+use Contributte\Datagrid\Storage\NoopStateStorage;
+use Contributte\Datagrid\Storage\SessionStateStorage;
+use Contributte\Datagrid\Tests\Files\TestingDatagridFactoryRouter;
+use Nette\Application\AbortException;
+use Tester\Assert;
+use Tester\TestCase;
+
+final class RememberStateTest extends TestCase
+{
+    /**
+     * This case is testing grid->setRememberState(true), in this case SessionStateStorage is used,
+     * and state is stored in session.
+     */
+    public function testDefaultSessionStateStorage(): void
+    {
+        $grid = $this->createGridWithRememberState(true);
+
+        Assert::type(SessionStateStorage::class, $grid->getStateStorage());
+
+        $this->simulateFilterSubmission($grid);
+        $this->assertFilterValueStored($grid, 'value');
+    }
+
+    /*
+     * This case is testing grid->setRememberState(false). NoopStateStorage is used in this case, which means
+     * that no state is stored.
+     */
+    public function testNoopStateStorage(): void
+    {
+        $grid = $this->createGridWithRememberState(false);
+
+        Assert::type(NoopStateStorage::class, $grid->getStateStorage());
+
+        $this->simulateFilterSubmission($grid);
+        $this->assertFilterValueStored($grid, null);
+    }
+
+    /**
+     * This case is testing grid->setColumnsHideable() side effect, in this case storage is used despite
+     * remember state being set to false. This is because hideable columns are stored in session
+     */
+    public function testRememberStateWithHideableColumns(): void
+    {
+        $grid = $this->createGridWithRememberState(false);
+        $grid->setColumnsHideable();
+
+        Assert::type(SessionStateStorage::class, $grid->getStateStorage());
+
+        $this->simulateFilterSubmission($grid);
+        $this->assertFilterValueStored($grid, 'value');
+    }
+
+
+    private function createGridWithRememberState(bool $rememberState): Datagrid
+    {
+        $factory = new TestingDatagridFactoryRouter();
+        /** @var Datagrid $grid */
+        $grid = $factory->createTestingDatagrid()->getComponent('grid');
+        $grid->setRememberState($rememberState);
+
+        return $grid;
+    }
+
+    private function simulateFilterSubmission(Datagrid $grid): void
+    {
+        $grid->addFilterText('test', 'Test filter');
+        $grid->setFilter(['test' => 'value']);
+
+        $filterForm = $grid->createComponentFilter();
+        Assert::exception(function () use ($grid, $filterForm): void {
+            $grid->filterSucceeded($filterForm);
+        }, AbortException::class);
+    }
+
+    private function assertFilterValueStored(Datagrid $grid, ?string $expectedValue): void
+    {
+        $stateStorage = $grid->getStateStorage();
+        $filters = $stateStorage->loadState('_grid_filters');
+
+        if ($expectedValue === null) {
+            Assert::null($filters['test'] ?? null);
+        } else {
+            Assert::same($expectedValue, $filters['test'] ?? null);
+        }
+    }
+}
+
+(new RememberStateTest())->run();


### PR DESCRIPTION
# Refactor session handling to use pluggable state storage

This PR introduces a pluggable state storage system that allows developers to use custom storage backends (database, cache, etc.) instead of being limited to session-only storage. This enables DataGrid state persistence across multiple devices/browsers and provides enhanced flexibility for distributed environments.

## Implementation

- **Introduced `IStateStorage` interface** with three methods: `loadState()`, `saveState()`, and `deleteState()`
- **Added two implementations:**
  - `SessionStateStorage` - maintains existing session-based behavior
  - `NoopStateStorage` - no-op implementation for when persistence isn't needed
- **Refactored `Datagrid` class:**
  - Replaced direct session access with state storage abstraction
  - Renamed session-related methods and properties to use "storage" terminology
  - Added `getStateStorage()` and `setStateStorage()` methods
  - Automatically selects appropriate storage based on `rememberState` and column hiding settings
- **Improved filter storage** by consolidating all filters under a single `_grid_filters` key instead of individual keys
- **Added deprecation notice** for `setStrictSessionFilterValues()` method
- **Updated internal naming** from "session" to "storage" throughout the codebase

## Usage Example

```php
// Use custom database storage
$grid->setStateStorage(new DatabaseStateStorage($user->getId()));
```

## Backward Compatibility

All existing functionality remains intact. The datagrid automatically uses `SessionStateStorage` when state persistence is enabled, ensuring existing applications continue to work without changes.

## Testing

Added some basic tests covering different storage scenarios including remember state.

## Notes
Documentation has not been updated yet - waiting for code review feedback before making documentation changes.