### PR TITLE
The `fa` prefix has been deprecated in v5.

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -86,7 +86,7 @@ class Datagrid extends Control
 		'_grid_hidden_columns_manipulated',
 	];
 
-	public static string $iconPrefix = 'fa fa-';
+	public static string $iconPrefix = 'fas fa-';
 
 	public static string $btnSecondaryClass = 'btn-default btn-secondary';
 


### PR DESCRIPTION
https://docs.fontawesome.com/v5/web/reference-icons

<img width="645" height="153" alt="image" src="https://github.com/user-attachments/assets/974730c3-9085-4e22-ab28-4bd49c7b30a5" />
