### PR TITLE
Patch 2

### DIFF
--- a/src/Traits/TButtonTryAddIcon.php
+++ b/src/Traits/TButtonTryAddIcon.php
@@ -17,7 +17,7 @@ trait TButtonTryAddIcon
 				$iconClass .= ' ' . Datagrid::$iconPrefix . $icon;
 			}
 
-			$el->addHtml(Html::el('span')->setAttribute('class', trim($iconClass)));
+			$el->addHtml(Html::el('i')->setAttribute('class', trim($iconClass)));
 
 			if (mb_strlen($name) > 1) {
 				$el->addHtml('&nbsp;');

--- a/tests/Cases/ColumnActionTest.phpt
+++ b/tests/Cases/ColumnActionTest.phpt
@@ -83,7 +83,7 @@ final class ColumnActionTest extends TestCase
 		$action->setIcon('user');
 
 		Assert::same(
-			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary"><span class="icon-user"></span>&nbsp;Do</a>',
+			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary"><i class="icon-user"></i>&nbsp;Do</a>',
 			$this->render($action)
 		);
 	}


### PR DESCRIPTION
Icons on buttons from the FontAwesome library didn’t work — they no longer use span, but i.